### PR TITLE
Use GLib for XDG

### DIFF
--- a/cozy/db.py
+++ b/cozy/db.py
@@ -1,10 +1,9 @@
 import os
 from peewee import *
-from xdg import *
-from gi.repository import GdkPixbuf
+from gi.repository import GLib, GdkPixbuf
 
 # first we get the data home and find the database if it exists
-data_dir = BaseDirectory.xdg_data_home + "/cozy/"
+data_dir = os.path.join(GLib.get_user_data_dir(), "cozy")
 if not os.path.exists(data_dir):
     os.makedirs(data_dir)
 


### PR DESCRIPTION
Since GLib is already a used, it is preferable using this, in favor of
the additional PyXDG dependency. The GLib implementation is also likely
better maintained, considering the last release of PyXDG was 2012-12-06.