### PR TITLE
set relief on volume button to normal

### DIFF
--- a/data/ui/main_window.ui
+++ b/data/ui/main_window.ui
@@ -691,7 +691,7 @@
                     <property name="focus_on_click">False</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Volume control</property>
-                    <property name="relief">none</property>
+                    <property name="relief">normal</property>
                     <property name="value">1</property>
                     <property name="size">button</property>
                     <property name="sensitive">False</property>


### PR DESCRIPTION
In my opinion, the volume button looks odd.
![cozy_vol_none](https://user-images.githubusercontent.com/21270245/35540776-c9868fa2-0557-11e8-83d9-962c900c3966.png)

Setting it's relief to normal looks better in my opinion.
![cozy_vol_normal](https://user-images.githubusercontent.com/21270245/35540780-ccbd16be-0557-11e8-93c5-dddc071b37e5.png)
