### PR TITLE
build with meson >= 0.40.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: multimedia
 Priority: optional
 Maintainer: Julian Geywitz <github@geigi.de>
 Build-Depends: debhelper (>= 9),
-               meson,
+               meson (>=0.40.0),
                libgtk-3-dev,
                python3,
                python3-pip,


### PR DESCRIPTION
I had to use meson from backports.  Build fails when using 0.37 on stretch.  This helps tell the builder that meson is out of date.

