### PR TITLE
Deb py policy 2.4.2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: multimedia
 Priority: optional
 Maintainer: Julian Geywitz <github@geigi.de>
 Build-Depends: debhelper (>= 9),
-               meson,
+               meson (>=0.40.0),
                libgtk-3-dev,
                python3,
                python3-pip,

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!@PYTHON@
 
 # main.py
 #

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 # main.py
 #

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,7 @@ conf.set('PYTHON_DIR', python_dir)
 conf.set('PYTHON_EXEC_DIR', join_paths(get_option('prefix'), python.sysconfig_path('stdlib')))
 conf.set('libexecdir', LIBEXEC_DIR)
 conf.set('VERSION', meson.project_version())
+conf.set('PYTHON', python_bin.path())
 
 subdir('data')
 subdir('po')


### PR DESCRIPTION
I'm using ```~/.local``` for my home python environment (in ~home, my default python is python3).  Cozy with the ```/usr/bin/env``` prefix works using  a "desktop launch", but wants to use my environment when called from an xterm.
