### PR TITLE
fedora specific dependency installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ If you like this project, consider supporting me on <a href="https://www.patreon
 - `gstreamer1.0-plugins-good`
 - `gstreamer1.0-libav` for mp4 support
 
+### Install requirements on Fedora
+```bash
+sudo dnf install meson glib glib2-devel python3 python3-devel file-libs python3-magic python3-mutagen gtk3 ghc-magic-devel python3-gstreamer1 gstreamer1-plugins-good gstreamer1-plugins-good-gtk gstreamer1-libav
+pip3 install --user python-magic libmagic peewee ninja file
+```
+
 ## Build
 ```bash
 $ git clone https://github.com/geigi/cozy.git


### PR DESCRIPTION
it took a little trial and error to work out how to get the requirements installed for a build on fedora. mostly it was a case of mapping the listed requirements with the fedora rpm package names.
- **python3-gstreamer1** was required to get sound working after a successful build
- **glib2-devel** was required for a successful meson build (to avoid error: `No such file or directory: 'glib-compile-resources'`)
- **ghc-magic-devel** was required for a successful `pip3 install file` (to avoid error: `fatal error: magic.h: No such file or directory`)