### PR TITLE
Replaced deprecated 'platform' package with 'distro' package

### DIFF
--- a/cozy/tools.py
+++ b/cozy/tools.py
@@ -3,7 +3,7 @@ import time
 import threading
 from threading import Thread, Event
 import logging as log
-import platform
+import distro
 import os
 from gi.repository import GLib, Gio
 import cozy.magic.magic as magic
@@ -33,7 +33,7 @@ def is_elementary():
         """
         Currently we are only checking for elementaryOS
         """
-        dist = platform.dist()
+        dist = distro.linux_distribution(full_distribution_name=False)
         log.debug(dist)
         if '"elementary"' in dist or 'elementary' in dist:
             return True

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ import os
 import signal
 import sys
 import traceback
-import platform
+import distro
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -68,7 +68,7 @@ class Application(Gtk.Application):
         gettext.install('com.github.geigi.cozy', localedir)
 
     def do_startup(self):
-        log.info(platform.dist())
+        log.info(distro.linux_distribution(full_distribution_name=False))
         log.info("Starting up cozy " + version)
         self.ui = CozyUI(pkgdatadir, self, version)
         init_db()


### PR DESCRIPTION
The platform package is deprecated and cozy won't build in python3.8 with it. 
This is a small PR to replace that deprecated package with 'distro', the recommended replacement.