### PR TITLE
Escape BookElement title

### DIFF
--- a/cozy/ui/book_element.py
+++ b/cozy/ui/book_element.py
@@ -1,4 +1,4 @@
-import os, subprocess
+import html, os, subprocess
 from gi.repository import Gtk, Gdk, GdkPixbuf, Pango, Gst
 
 import cozy.control.player as player
@@ -228,7 +228,7 @@ class BookElement(Gtk.FlowBoxChild):
 
         # label contains the book name and is limited to x chars
         title_label = Gtk.Label.new("")
-        title = tools.shorten_string(self.book.name, MAX_BOOK_LENGTH)
+        title = html.escape(tools.shorten_string(self.book.name, MAX_BOOK_LENGTH))
         title_label.set_markup("<b>" + title + "</b>")
         title_label.set_xalign(0.5)
         title_label.set_line_wrap(Pango.WrapMode.WORD_CHAR)


### PR DESCRIPTION
Currently, titles containing e.g. ampersands (in my case: _The City & the City_), cause a Gtk warning:

> (com.github.geigi.cozy:22317): Gtk-WARNING **: 20:59:44.758: Failed to set text '\<b\>The City & the City\</b\>' from markup due to error parsing markup: Error on line 1: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity — escape ampersand as \&amp;

and the title is not rendered:
![ampersand_in_title](https://user-images.githubusercontent.com/827324/80522496-323c8b00-897c-11ea-8b25-8c07effe1239.png)
