### PR TITLE
TrackElement: use monospace font for duration

### DIFF
--- a/cozy/ui/track_element.py
+++ b/cozy/ui/track_element.py
@@ -62,6 +62,7 @@ class TrackElement(Gtk.EventBox):
         title_label.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
 
         dur_label.set_text(seconds_to_str(self.track.length))
+        dur_label.get_style_context().add_class("monospace")
         dur_label.set_halign(Gtk.Align.END)
         dur_label.props.margin = 4
         dur_label.set_margin_left(60)

--- a/data/ui/application_default.css
+++ b/data/ui/application_default.css
@@ -27,3 +27,8 @@
 .h5 {
   font-size: 115%;
 }
+
+.monospace {
+  font-family: monospace;
+}
+


### PR DESCRIPTION
This is merely a small suggestion but I think it looks nicer to use a monospace font for the duration so that it's better aligned.
![comparison](https://user-images.githubusercontent.com/4464481/81586334-a41dc700-93b5-11ea-8182-160bba476e27.png)

