### PR TITLE
Save playback speed for a book on its change

### DIFF
--- a/cozy/control/playback_speed.py
+++ b/cozy/control/playback_speed.py
@@ -26,7 +26,6 @@ class PlaybackSpeed(EventSender):
         self.speed_scale.add_mark(1.0, Gtk.PositionType.RIGHT, None)
         self.speed_scale.set_increments(0.02, 0.05)
         self.speed_scale.connect("value-changed", self.__set_playback_speed)
-        self.speed_scale.connect("button-release-event", self.__on_scale_click_released)
 
         player.add_player_listener(self.__player_changed)
 
@@ -42,18 +41,16 @@ class PlaybackSpeed(EventSender):
 
     def __set_playback_speed(self, widget):
         """
-        Set the playback speed.
+        Set and save the playback speed.
         Update playback speed label.
         """
         self.speed = round(self.speed_scale.get_value(), 2)
         self.speed_label.set_text('{speed:3.1f} x'.format(speed=self.speed))
         
         player.set_playback_speed(self.speed)
+        player.save_current_playback_speed()
 
         self.emit_event("playback-speed-changed", self.speed)
-
-    def __on_scale_click_released(self, widget, sender):
-        player.save_current_playback_speed()
 
     def __player_changed(self, event, message):
         """


### PR DESCRIPTION
Fixes #291.

Problem:
- The bug was not saving playback speed of the book persistently when it's changed using e.g. mouse wheel.

Solution:
- Now any change of playback speed leads to saving it. 

Environment:
- Arch, kernel version 5.7.12
- Python 3.8