### PR TITLE
docs: add voidlinux to available distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Cozy is a modern audiobook player for Linux.
 - Developed on Fedora and tested under elementaryOS
 
 # Install
-| elementaryOS | openSUSE | Arch Linux | Solus | Flatpak (other) |
-|--------------|:----------:|:------------:|:-----:|-----------------|
-| <a href="https://appcenter.elementary.io/com.github.geigi.cozy"><img src="https://appcenter.elementary.io/badge.svg" alt="Get it on AppCenter"></a> | <center><a href="https://software.opensuse.org/package/cozy">cozy</a> | <a href="https://aur.archlinux.org/packages/cozy-audiobooks/">cozy-audiobooks</a></center> | <a href="https://dev.getsol.us/source/cozy/">cozy</a> | <a href='https://flathub.org/apps/details/com.github.geigi.cozy'><img width='150' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a> |
+| elementaryOS | openSUSE | Arch Linux | Solus | VoidLinux | Flatpak (other) |
+|--------------|:----------:|:------------:|:-----:|:-----------------:| --- |
+| <a href="https://appcenter.elementary.io/com.github.geigi.cozy"><img src="https://appcenter.elementary.io/badge.svg" alt="Get it on AppCenter"></a> | <center><a href="https://software.opensuse.org/package/cozy">cozy</a> | <a href="https://aur.archlinux.org/packages/cozy-audiobooks/">cozy-audiobooks</a></center> | <a href="https://dev.getsol.us/source/cozy/">cozy</a> | <a href="https://github.com/void-linux/void-packages/tree/master/srcpkgs/cozy">cozy</a> | <a href='https://flathub.org/apps/details/com.github.geigi.cozy'><img width='150' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a> | 
 
 ## macOS
 **Currently discontinued**


### PR DESCRIPTION
someone has packaged cozy to voidlinux, install with `xbps-install cozy`: https://github.com/void-linux/void-packages/tree/master/srcpkgs/cozy