### PR TITLE
Fix scan library not adding new files.

### DIFF
--- a/cozy/media/importer.py
+++ b/cozy/media/importer.py
@@ -77,7 +77,7 @@ class Importer(EventSender):
 
             if len(media_files) != 0:
                 self._library.insert_many(media_files)
-            else:
+            if progress >= files_count:
                 break
         pool.close()
 


### PR DESCRIPTION
I have found that if the first 100 files in "files_to_scan" are not media files, the rest of files_to_scan are not processed. Checking the current progress number [of files] against the total number instead, allows to import all new files.