### PR TITLE
Prevent book duplications when title spelling is inconsistent

### DIFF
--- a/cozy/extensions/is_same_book.py
+++ b/cozy/extensions/is_same_book.py
@@ -1,0 +1,2 @@
+def is_same_book(book_a: str, book_b: str) -> bool:
+    return book_a.casefold() == book_b.casefold()

--- a/test/cozy/extensions/test_is_same_book.py
+++ b/test/cozy/extensions/test_is_same_book.py
@@ -1,0 +1,33 @@
+from cozy.extensions.is_same_book import is_same_book
+
+
+def test_books_with_identical_spelling_are_same():
+    book_a = "Dummy Book Title"
+    book_b = "Dummy Book Title"
+    result = is_same_book(book_a, book_b)
+
+    assert result is True
+
+
+def test_books_with_inconsistent_spelling_are_same():
+    book_a = "Dummy Book Title"
+    book_b = "Dummy book title"
+    result = is_same_book(book_a, book_b)
+
+    assert result is True
+
+
+def test_different_books_are_not_same():
+    book_a = "First Dummy Book Title"
+    book_b = "Second Dummy Book Title"
+    result = is_same_book(book_a, book_b)
+
+    assert result is False
+
+
+def test_books_without_title_are_not_same():
+    book_a = "First Dummy Book Title"
+    book_b = ""
+    result = is_same_book(book_a, book_b)
+
+    assert result is False

--- a/test/cozy/model/test_database_importer.py
+++ b/test/cozy/model/test_database_importer.py
@@ -335,7 +335,9 @@ def test_prepare_db_objects_updates_existing_book_regardless_of_spelling(mocker)
     spy = mocker.spy(database_importer, "_update_book_db_object")
 
     File.create(path="New test File", modified=1234567)
+    File.create(path="Another test File", modified=1234568)
     chapter = Chapter("New Chapter", 0, 1234567, 999)
+    another_chapter = Chapter("Another Chapter", 0, 1234567, 999)
     media_file = MediaFile(book_name="TeSt bOOk",
                            author="New Author2",
                            reader="New Reader",
@@ -344,10 +346,18 @@ def test_prepare_db_objects_updates_existing_book_regardless_of_spelling(mocker)
                            path="New test File",
                            modified=1234567,
                            chapters=[chapter])
+    another_media_file = MediaFile(book_name="TEST BOOK",
+                           author="New Author2",
+                           reader="New Reader",
+                           disk=999,
+                           cover=b"cover",
+                           path="Another test File",
+                           modified=1234568,
+                           chapters=[another_chapter])
 
-    res_dict = database_importer._prepare_track_db_objects([media_file])
+    res_dict = database_importer._prepare_track_db_objects([media_file, another_media_file])
 
-    assert len(list(res_dict)) == 1
+    assert len(list(res_dict)) == 2
     spy.assert_called_once()
 
 


### PR DESCRIPTION
When audio files use different case for the same book name in their metadata, they now appear as a single book in the library.

Before:

![Duplicated books in Cozy](https://user-images.githubusercontent.com/8396076/119581844-4b9c4a80-bdbb-11eb-978e-e2830ee3bb9c.png)

After:

![Single book in Cozy](https://user-images.githubusercontent.com/8396076/119581866-57880c80-bdbb-11eb-8bcc-1bc24cb5ba8b.png)

Notice different spelling of the words "and" and "the" in the first screengrab.

Fixes #489
