### PR TITLE
Ensure chapter titles derived from filenames are decoded

### DIFF
--- a/cozy/media/tag_reader.py
+++ b/cozy/media/tag_reader.py
@@ -54,7 +54,8 @@ class TagReader:
     def _get_book_name_fallback(self):
         path = os.path.normpath(self.uri)
         directory_path = os.path.dirname(path)
-        return os.path.basename(directory_path)
+        directory = os.path.basename(directory_path)
+        return unquote(directory)
 
     def _get_author(self):
         authors = self._get_string_list(Gst.TAG_COMPOSER)
@@ -89,7 +90,8 @@ class TagReader:
 
     def _get_track_name_fallback(self):
         filename = os.path.basename(self.uri)
-        return os.path.splitext(filename)[0]
+        filename_without_extension = os.path.splitext(filename)[0]
+        return unquote(filename_without_extension)
 
     def _get_chapters(self):
         if self.uri.lower().endswith("m4b") and self._mutagen_supports_chapters():

--- a/test/cozy/media/test_tag_reader.py
+++ b/test/cozy/media/test_tag_reader.py
@@ -62,10 +62,26 @@ def test_track_name_fallback_is_filename(discoverer_mocks):
     assert tag_reader._get_track_name_fallback() == "a nice file"
 
 
+def test_track_name_fallback_is_unescaped_filename(discoverer_mocks):
+    from cozy.media.tag_reader import TagReader
+
+    tag_reader = TagReader("file://abc/def/a%20nice%20file.mp3", discoverer_mocks.info)
+
+    assert tag_reader._get_track_name_fallback() == "a nice file"
+
+
 def test_book_title_fallback_is_parent_directory_name(discoverer_mocks):
     from cozy.media.tag_reader import TagReader
 
     tag_reader = TagReader("file://abc/def hij/a nice file.mp3", discoverer_mocks.info)
+
+    assert tag_reader._get_book_name_fallback() == "def hij"
+
+
+def test_book_title_fallback_is_unescaped_parent_directory_name(discoverer_mocks):
+    from cozy.media.tag_reader import TagReader
+
+    tag_reader = TagReader("file://abc/def%20hij/a%20nice%20file.mp3", discoverer_mocks.info)
 
     assert tag_reader._get_book_name_fallback() == "def hij"
 


### PR DESCRIPTION
When an audio file has a missing "Title" metatag, the track name is pulled from the file name itself. And we are now ensuring any URL-encoded characters like spaces (%20) get decoded accordingly.

Fixes issue #524