### PR TITLE
PPA for Ubuntu 20.10 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ Head over to [Matrix](https://matrix.to/#/#cozy:gnome.org?via=matrix.org&via=gno
 |--------|:---------:|
 | Flatpak | <a href='https://flathub.org/apps/details/com.github.geigi.cozy'><img width='150' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a> |
 | openSUSE | <center><a href="https://software.opensuse.org/package/cozy">cozy</a> |
-| Arch Linux | <a href="https://aur.archlinux.org/packages/cozy-audiobooks/">cozy-audiobooks</a></center> |
+| Arch Linux (AUR) | <a href="https://aur.archlinux.org/packages/cozy-audiobooks/">cozy-audiobooks</a></center> |
 | VoidLinux | <a href="https://github.com/void-linux/void-packages/tree/master/srcpkgs/cozy">cozy</a> |
 | Solus | <a href="https://dev.getsol.us/source/cozy/">cozy</a> |
 | MX Linux | <center><a href="https://forum.mxlinux.org/viewtopic.php?p=621071#p621071">Cozy</a> |
 | elementaryOS | Currently out of date. Please use Flatpak for now. |
+| Ubuntu (PPA) | <center><a href="https://launchpad.net/~cozy-team/+archive/ubuntu/cozy">cozy</a> |
 
 
 ## elementaryOS


### PR DESCRIPTION
I have created a PPA for Ubuntu 20.10 and above (for x86_64, arm and powerpc).

The .deb package in the PPA also works in 20.04, but one would have to install the latest version of peewee from pip, and also libhandy-1 from [somewhere else](https://launchpad.net/~apandada1/+archive/ubuntu/libhandy-1).

This comes handy in systems where flatpak is not available, e.g. Ubuntu running inside Termux in an Android Phone. I also tested it in my computer.
![Screenshot_2021-06-05-19-02-58-081_com realvnc viewer android](https://user-images.githubusercontent.com/3063132/120893535-7004ec00-c631-11eb-8026-37bf84eab3d6.jpg)

<sup>Cozy (from PPA) running in Ubuntu in my Android Phone </sup>

I am watching releases, and I will update it when a new release is available.

