### PR TITLE
Render track listing on a separate thread for better UX

### DIFF
--- a/cozy/ui/book_detail_view.py
+++ b/cozy/ui/book_detail_view.py
@@ -222,8 +222,8 @@ class BookDetailView(Gtk.EventBox):
         self.total_text.set_visible(True)
         self._set_book_download_status()
 
-        self._on_play_changed()
         self._on_current_chapter_changed()
+        self._on_play_changed()
         self._on_book_available_changed()
 
         self.chapters_stack.set_visible_child_name("chapters_wrapper")

--- a/cozy/ui/book_detail_view.py
+++ b/cozy/ui/book_detail_view.py
@@ -201,9 +201,9 @@ class BookDetailView(Gtk.EventBox):
                 return
 
             if disk_number != chapter.disk and disk_count > 1:
-                Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE, self._add_disk, chapter)
+                Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE, self._add_disk, book.id, chapter)
 
-            Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE, self._add_chapter, chapter)
+            Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE, self._add_chapter, book.id, chapter)
 
             disk_number = chapter.disk
 
@@ -235,13 +235,19 @@ class BookDetailView(Gtk.EventBox):
             self.download_switch.set_active(self._view_model.book.offline)
             self.download_switch.handler_unblock_by_func(self._download_switch_changed)
 
-    def _add_disk(self, chapter: Chapter):
+    def _add_disk(self, book_id: int, chapter: Chapter):
+        if book_id != self._view_model.book.id:
+            return
+
         disc_element = DiskElement(chapter.disk)
         self.chapter_box.add(disc_element)
         disc_element.show_all()
         self._chapters_event.set()
 
-    def _add_chapter(self, chapter: Chapter):
+    def _add_chapter(self, book_id: int, chapter: Chapter):
+        if book_id != self._view_model.book.id:
+            return
+
         chapter_element = ChapterElement(chapter)
         chapter_element.connect("play-pause-clicked", self._play_chapter_clicked)
         self.chapter_box.add(chapter_element)

--- a/cozy/ui/book_detail_view.py
+++ b/cozy/ui/book_detail_view.py
@@ -126,6 +126,7 @@ class BookDetailView(Gtk.EventBox):
         self.published_text.set_visible(False)
         self.total_label.set_visible(False)
         self.total_text.set_visible(False)
+        self.unavailable_box.set_visible(False)
 
         self.book_label.set_text(book.name)
         self.author_label.set_text(book.author)

--- a/cozy/ui/book_detail_view.py
+++ b/cozy/ui/book_detail_view.py
@@ -132,7 +132,6 @@ class BookDetailView(Gtk.EventBox):
 
         self._display_external_section()
         self._set_progress()
-        self._on_play_changed()
 
         self._toolbar_revealer.set_reveal_child(False)
 
@@ -218,9 +217,12 @@ class BookDetailView(Gtk.EventBox):
         self.total_label.set_text(self._view_model.total_text)
         self.total_label.set_visible(True)
         self.total_text.set_visible(True)
-        self._on_current_chapter_changed()
         self._set_book_download_status()
+
+        self._on_play_changed()
+        self._on_current_chapter_changed()
         self._on_book_available_changed()
+
         self.chapters_stack.set_visible_child_name("chapters_wrapper")
 
     def _display_external_section(self):

--- a/cozy/ui/book_detail_view.py
+++ b/cozy/ui/book_detail_view.py
@@ -109,6 +109,8 @@ class BookDetailView(Gtk.EventBox):
             reporter.warning("BookDetailView", msg)
             return
 
+        self._chapters_event.clear()
+
         book = self._view_model.book
 
         self.chapters_stack.set_visible_child_name("chapters_loader")

--- a/cozy/ui/book_detail_view.py
+++ b/cozy/ui/book_detail_view.py
@@ -50,9 +50,9 @@ class BookDetailView(Gtk.EventBox):
 
     unavailable_box: Gtk.Box = Gtk.Template.Child()
 
+    chapters_stack: Gtk.Stack = Gtk.Template.Child()
     chapter_box: Gtk.Box = Gtk.Template.Child()
     book_overview_scroller: Gtk.ScrolledWindow = Gtk.Template.Child()
-
 
     _view_model: BookDetailViewModel = inject.attr(BookDetailViewModel)
     _artwork_cache: ArtworkCache = inject.attr(ArtworkCache)
@@ -113,6 +113,7 @@ class BookDetailView(Gtk.EventBox):
         # are ready
         self._clear_chapter_box()
 
+        self.chapters_stack.set_visible_child_name("chapters_loader")
         self._chapters_thread_locked = False
         self._run_display_chapters_job(book)
 
@@ -211,6 +212,7 @@ class BookDetailView(Gtk.EventBox):
         self._on_current_chapter_changed()
         self._set_book_download_status()
         self._on_book_available_changed()
+        self.chapters_stack.set_visible_child_name("chapters_wrapper")
 
     def _display_external_section(self):
         external = self._view_model.is_book_external

--- a/cozy/ui/book_detail_view.py
+++ b/cozy/ui/book_detail_view.py
@@ -33,6 +33,7 @@ class BookDetailView(Gtk.EventBox):
     author_label: Gtk.Label = Gtk.Template.Child()
     last_played_label: Gtk.Label = Gtk.Template.Child()
     total_label: Gtk.Label = Gtk.Template.Child()
+    total_text: Gtk.Label = Gtk.Template.Child()
 
     remaining_label: Gtk.Label = Gtk.Template.Child()
     book_progress_bar: Gtk.ProgressBar = Gtk.Template.Child()
@@ -123,6 +124,8 @@ class BookDetailView(Gtk.EventBox):
 
         self.published_label.set_visible(False)
         self.published_text.set_visible(False)
+        self.total_label.set_visible(False)
+        self.total_text.set_visible(False)
 
         self.book_label.set_text(book.name)
         self.author_label.set_text(book.author)
@@ -200,6 +203,8 @@ class BookDetailView(Gtk.EventBox):
 
     def _on_chapters_displayed(self):
         self.total_label.set_text(self._view_model.total_text)
+        self.total_label.set_visible(True)
+        self.total_text.set_visible(True)
         self._on_current_chapter_changed()
         self._set_book_download_status()
         self._on_book_available_changed()

--- a/cozy/ui/book_detail_view.py
+++ b/cozy/ui/book_detail_view.py
@@ -279,10 +279,10 @@ class BookDetailView(Gtk.EventBox):
 
     def _interrupt_chapters_jobs(self):
         self._chapters_job_locked = True
-        # TODO Confirm if this is even needed
+
         try:
             self._chapters_thread.join(timeout=0.2)
-        except Exception as e:
+        except AttributeError as e:
             pass
 
     def _prepare_chapters_job(self):

--- a/cozy/ui/book_detail_view.py
+++ b/cozy/ui/book_detail_view.py
@@ -148,7 +148,7 @@ class BookDetailView(Gtk.EventBox):
         else:
             log.error("_current_selected_chapter is null. Skipping...")
             reporter.error("book_detail_view",
-                           "_current_selected_chapter was NULL. No ply/pause chapter icon was changed")
+                           "_current_selected_chapter was NULL. No play/pause chapter icon was changed")
 
     def _on_book_available_changed(self):
         info_visibility = not self._view_model.is_book_available

--- a/cozy/ui/book_detail_view.py
+++ b/cozy/ui/book_detail_view.py
@@ -195,14 +195,14 @@ class BookDetailView(Gtk.EventBox):
 
     def _display_chapters(self, book: Book, callback: Callable):
         disk_number = -1
-        disk_count = self._view_model.disk_count
+        multiple_disks = self._view_model.disk_count > 1
 
         for chapter in book.chapters:
             if self._chapters_job_locked:
                 self._clear_chapter_box()
                 return
 
-            if disk_number != chapter.disk and disk_count > 1:
+            if multiple_disks and disk_number != chapter.disk:
                 Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE, self._add_disk, book.id, chapter)
 
             Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE, self._add_chapter, book.id, chapter)

--- a/cozy/view_model/book_detail_view_model.py
+++ b/cozy/view_model/book_detail_view_model.py
@@ -57,6 +57,9 @@ class BookDetailViewModel(Observable, EventSender):
 
     @book.setter
     def book(self, value: Book):
+        if self._book == value:
+            return
+
         if self._book:
             self._book.remove_bind("current_chapter", self._on_book_current_chapter_changed)
             self._book.remove_bind("last_played", self._on_book_last_played_changed)

--- a/data/ui/book_detail.ui
+++ b/data/ui/book_detail.ui
@@ -251,7 +251,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel">
+                      <object class="GtkLabel" id="total_text">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>

--- a/data/ui/book_detail.ui
+++ b/data/ui/book_detail.ui
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <template class="BookDetail" parent="GtkEventBox">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkButton" id="back_button">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
             <property name="halign">start</property>
-            <property name="margin_left">10</property>
-            <property name="margin_top">10</property>
+            <property name="margin-left">10</property>
+            <property name="margin-top">10</property>
             <property name="relief">none</property>
-            <property name="always_show_image">True</property>
+            <property name="always-show-image">True</property>
             <child>
               <object class="GtkImage">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">go-previous-symbolic</property>
-                <property name="use_fallback">True</property>
+                <property name="can-focus">False</property>
+                <property name="icon-name">go-previous-symbolic</property>
+                <property name="use-fallback">True</property>
               </object>
             </child>
             <style>
@@ -41,28 +41,28 @@
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="valign">center</property>
-            <property name="margin_left">10</property>
-            <property name="margin_right">10</property>
-            <property name="margin_top">40</property>
-            <property name="margin_bottom">40</property>
+            <property name="margin-left">10</property>
+            <property name="margin-right">10</property>
+            <property name="margin-top">40</property>
+            <property name="margin-bottom">40</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkImage" id="cover_image">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="receives_default">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">True</property>
                     <property name="halign">center</property>
-                    <property name="margin_bottom">35</property>
+                    <property name="margin-bottom">35</property>
                     <property name="stock">gtk-missing-image</property>
                     <property name="icon_size">6</property>
                   </object>
@@ -74,14 +74,14 @@
                 </child>
                 <child>
                   <object class="GtkLabel" id="book_label">
-                    <property name="width_request">250</property>
+                    <property name="width-request">250</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="valign">end</property>
                     <property name="label">Book name</property>
                     <property name="justify">center</property>
                     <property name="wrap">True</property>
-                    <property name="max_width_chars">25</property>
+                    <property name="max-width-chars">25</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -97,15 +97,15 @@
                 </child>
                 <child>
                   <object class="GtkLabel" id="author_label">
-                    <property name="width_request">250</property>
+                    <property name="width-request">250</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="valign">start</property>
-                    <property name="margin_bottom">15</property>
+                    <property name="margin-bottom">15</property>
                     <property name="label">Book author</property>
                     <property name="justify">center</property>
                     <property name="wrap">True</property>
-                    <property name="max_width_chars">30</property>
+                    <property name="max-width-chars">30</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -123,22 +123,22 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
-                    <property name="margin_bottom">15</property>
+                    <property name="margin-bottom">15</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkBox" id="download_box">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="valign">center</property>
                         <child>
                           <object class="GtkImage" id="download_image">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">download-symbolic</property>
+                            <property name="can-focus">False</property>
+                            <property name="icon-name">download-symbolic</property>
                             <property name="icon_size">3</property>
                           </object>
                           <packing>
@@ -150,9 +150,9 @@
                         <child>
                           <object class="GtkLabel" id="download_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_left">5</property>
-                            <property name="margin_right">4</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">4</property>
                             <property name="label" translatable="yes">Download</property>
                           </object>
                           <packing>
@@ -171,7 +171,7 @@
                     <child>
                       <object class="GtkSwitch" id="download_switch">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
                       </object>
@@ -189,16 +189,17 @@
                   </packing>
                 </child>
                 <child>
+                  <!-- n-columns=3 n-rows=4 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_bottom">20</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-bottom">20</property>
                     <property name="hexpand">True</property>
-                    <property name="column_spacing">5</property>
+                    <property name="column-spacing">5</property>
                     <child>
                       <object class="GtkLabel" id="remaining_text">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Remaining</property>
@@ -207,53 +208,53 @@
                         </style>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">3</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">3</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="remaining_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="hexpand">True</property>
                         <property name="label">label</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">3</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">3</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="total_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="hexpand">True</property>
                         <property name="label">label</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">2</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">2</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="last_played_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="hexpand">True</property>
                         <property name="label">label</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="total_text">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Total</property>
@@ -262,14 +263,14 @@
                         </style>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">2</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">2</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Last played</property>
@@ -278,14 +279,14 @@
                         </style>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="published_text">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
                         <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Published</property>
@@ -294,22 +295,34 @@
                         </style>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="published_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="hexpand">True</property>
                         <property name="label">label</property>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                       </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
@@ -321,16 +334,16 @@
                 <child>
                   <object class="GtkBox" id="unavailable_box">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="tooltip_text" translatable="yes">Some or all files of this book cannot be found.</property>
+                    <property name="can-focus">False</property>
+                    <property name="tooltip-text" translatable="yes">Some or all files of this book cannot be found.</property>
                     <property name="halign">center</property>
-                    <property name="margin_bottom">20</property>
+                    <property name="margin-bottom">20</property>
                     <property name="spacing">4</property>
                     <child>
                       <object class="GtkImage">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="icon_name">info-symbolic</property>
+                        <property name="can-focus">False</property>
+                        <property name="icon-name">info-symbolic</property>
                         <style>
                           <class name="unavailable_image"/>
                         </style>
@@ -344,7 +357,7 @@
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">unavailable</property>
                         <style>
                           <class name="unavailable_label"/>
@@ -368,12 +381,12 @@
                 </child>
                 <child>
                   <object class="GtkProgressBar" id="book_progress_bar">
-                    <property name="width_request">250</property>
+                    <property name="width-request">250</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="halign">center</property>
                     <property name="valign">start</property>
-                    <property name="show_text">True</property>
+                    <property name="show-text">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -384,21 +397,21 @@
                 <child>
                   <object class="GtkButtonBox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_top">20</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-top">20</property>
                     <property name="orientation">vertical</property>
-                    <property name="layout_style">start</property>
+                    <property name="layout-style">start</property>
                     <child>
                       <object class="GtkButton" id="play_book_button">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <property name="relief">none</property>
                         <child>
                           <object class="GtkImage" id="play_img">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="icon_name">media-playback-start-symbolic</property>
+                            <property name="can-focus">True</property>
+                            <property name="icon-name">media-playback-start-symbolic</property>
                             <property name="icon_size">3</property>
                           </object>
                         </child>
@@ -427,35 +440,73 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox">
+              <object class="GtkStack" id="chapters_stack">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">False</property>
+                <property name="receives-default">True</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
-                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="valign">start</property>
+                    <property name="margin-end">8</property>
+                    <child>
+                      <object class="GtkSpinner">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="active">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="chapters_loading_text">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Loading chapters, please wait...</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="padding">5</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="name">chapters_loader</property>
+                    <property name="title" translatable="yes">page1</property>
+                  </packing>
+                </child>
                 <child>
                   <object class="GtkScrolledWindow" id="book_overview_scroller">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
-                    <property name="hscrollbar_policy">never</property>
-                    <property name="shadow_type">in</property>
-                    <property name="propagate_natural_width">True</property>
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="shadow-type">in</property>
+                    <property name="propagate-natural-width">True</property>
                     <child>
                       <object class="GtkViewport" id="track_list_container">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">none</property>
                         <child>
                           <object class="GtkBox" id="chapter_box">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="valign">start</property>
-                            <property name="margin_left">8</property>
-                            <property name="margin_right">8</property>
-                            <property name="margin_top">8</property>
-                            <property name="margin_bottom">8</property>
+                            <property name="margin-start">8</property>
+                            <property name="margin-end">8</property>
+                            <property name="margin-top">8</property>
+                            <property name="margin-bottom">8</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <placeholder/>
@@ -472,9 +523,9 @@
                     </style>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
+                    <property name="name">chapters_wrapper</property>
+                    <property name="title" translatable="yes">page0</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
## Motivation and context
This PR is inspired by popular UX patterns in modern Web UI frameworks like React where it is favoured to immediately respond to user interactions even if the screen or widget might not be fully ready yet. A typical example here is presenting users with less dynamic parts of the page as well as a progress indicator or skeleton screen while a slow network request is still running in background.

The transition from the book listing to the book screen is not currently using this pattern in Cozy so if you are on a more modest hardware and have books with a large number of chapters and tracks in your library, you may experience the UI being blocked as it might take several seconds for the details page to actually show up. This is not ideal as it is not obvious to the user if they should wait or maybe the application has hung.

These changes aim at addressing this issue by rendering elements of the book summary panel on the left hand side as soon as a book has been selected and concurrently loading the disk/track listing on the right in background.

This should mostly benefit users on less powerful machines and should not really impact users running Cozy on more powerful hardware. 

This PR addresses one scenario described under issue #521

## Technical notes
Resource-consuming and expensive chapter-loading database operations have been delegated to a background thread to speed up the rendering process.

## Tasks
- [x] Test code changes on a RaspberryPi to confirm the UX has indeed improved on slower hardware
- [x] Hide Total while chapters are being loaded as this information doesn't seem to be available before that's completed
- [x] Progress indicator in the chapter panel while the data is being loaded
- [x] Decide what to do with the "Unavailable" badge in the book summary panel on the left hand side while the chapters are loading
- [x] Confirm it is safe to not explicitly terminate the background thread e.g. when users close the application when that thread is still active
- [ ] Translate the loading message
- [x] Fix remaining `_current_selected_chapter is null` console errors
- [ ] Address Code Climate issues
- [x] Sometimes the track listing gets completely messed up (chapters and tracks get mixed up and duplicated)