### PR TITLE
Fix double space in "What's new  in Cozy"

### DIFF
--- a/data/ui/whats_new_importer.ui
+++ b/data/ui/whats_new_importer.ui
@@ -14,7 +14,7 @@
       <object class="GtkLabel">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">What's new  in Cozy</property>
+        <property name="label" translatable="yes">What's new in Cozy</property>
         <style>
           <class name="h1"/>
         </style>

--- a/data/ui/whats_new_m4b.ui
+++ b/data/ui/whats_new_m4b.ui
@@ -14,7 +14,7 @@
       <object class="GtkLabel">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">What's new  in Cozy</property>
+        <property name="label" translatable="yes">What's new in Cozy</property>
         <style>
           <class name="h1"/>
         </style>

--- a/po/com.github.geigi.cozy.pot
+++ b/po/com.github.geigi.cozy.pot
@@ -652,7 +652,7 @@ msgid "Continue"
 msgstr ""
 
 #: data/ui/whats_new_importer.ui:17 data/ui/whats_new_m4b.ui:17
-msgid "What's new  in Cozy"
+msgid "What's new in Cozy"
 msgstr ""
 
 #: data/ui/whats_new_importer.ui:52


### PR DESCRIPTION
I noticed this didn't look right as soon as I opened the app for the
first time!

To make this change I just did:

    find . -type f | xargs sed -i "s/What's new  in Cozy/What's new in Cozy/g"

I hope that's fine for the .po files.
