### PR TITLE
Rename header bar text when importing

### DIFF
--- a/cozy/view_model/headerbar_view_model.py
+++ b/cozy/view_model/headerbar_view_model.py
@@ -88,7 +88,7 @@ class HeaderbarViewModel(Observable, EventSender):
             self._work_progress = message
             self._notify("work_progress")
         elif event == "scan" and message == ScanStatus.STARTED:
-            self._start_working(_("Importing Audiobooks"))
+            self._start_working(_("Refreshing audio book collection"))
         elif event == "scan" and message == ScanStatus.SUCCESS:
             self._stop_working()
 


### PR DESCRIPTION
In an effort to be more descriptive I would rename "Importing
Audiobooks" to "Refreshing audio book collectoin".
I'm hoping this makes it clearer for users to understand that books are
not copied at this step.

Fixes https://github.com/geigi/cozy/issues/309