### PR TITLE
Opt-in to dark mode user preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for detailed instructions and developing Co
 - `python3`
 - `meson >= 0.40.0` as build system
 - `gtk3 >= 3.22`
-- `libhandy >= 1.0.0`
+- `libhandy >= 1.5.0`
 - `granite >= 5.3.0`
 - `libdazzle >= 3.34.0`
 - `peewee >= 3.9.6` as object relation mapper

--- a/cozy/application.py
+++ b/cozy/application.py
@@ -86,6 +86,8 @@ class Application(Gtk.Application):
         init_db()
         Gtk.Application.do_startup(self)
         Handy.init()
+        manager = Handy.StyleManager.get_default()
+        manager.set_color_scheme(Handy.ColorScheme.PREFER_LIGHT)
         log.info("libhandy version: {}".format(Handy._version))
         self.ui.startup()
 

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ else
 endif
 
 dependency('glib-2.0')
-dependency('libhandy-1', version: '>= 1.0.0')
+dependency('libhandy-1', version: '>= 1.5.0')
 granite_dependency = dependency('granite', version: '>= 5.3.0')
 
 # from https://github.com/AsavarTzeth/pulseeffects/blob/master/meson.build


### PR DESCRIPTION
Starting from GNOME 42, a user preference¹ for dark mode will be added
to Settings, this MR opts-in to follow the user preference.

¹ The preference is DE agnostic and will be supported by the popular
DEs.