### PR TITLE
Two Fixes for Cozy

### DIFF
--- a/cozy/ui/main_view.py
+++ b/cozy/ui/main_view.py
@@ -169,6 +169,7 @@ class CozyUI(EventSender, metaclass=Singleton):
         help_action = Gio.SimpleAction.new("help", None)
         help_action.connect("activate", self.help)
         self.app.add_action(help_action)
+        self.app.set_accels_for_action("app.help", ["F1"])
 
         about_action = Gio.SimpleAction.new("about", None)
         about_action.connect("activate", self.about)

--- a/data/ui/gresource.xml
+++ b/data/ui/gresource.xml
@@ -32,5 +32,6 @@
     <file preprocess="xml-stripblanks">whats_new_library.ui</file>
     <file preprocess="xml-stripblanks">whats_new_m4b.ui</file>
     <file preprocess="xml-stripblanks">whats_new_m4b_chapter.ui</file>
+    <file preprocess="xml-stripblanks" alias="gtk/help-overlay.ui">help_overlay.ui</file>
   </gresource>
 </gresources>

--- a/data/ui/help_overlay.ui
+++ b/data/ui/help_overlay.ui
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <object class="GtkShortcutsWindow" id="help_overlay">
+    <property name="modal">true</property>
+    <child>
+      <object class="GtkShortcutsSection">
+        <property name="visible">true</property>
+        <property name="section-name">shortcuts</property>
+        <property name="max-height">10</property>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="visible">true</property>
+            <property name="title" translatable="yes" context="shortcut window">General</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">true</property>
+                <property name="title" translatable="yes" context="shortcut window">Show help</property>
+                <property name="action-name">app.help</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">true</property>
+                <property name="title" translatable="yes" context="shortcut window">Play/Pause</property>
+                <property name="action-name">app.play_pause</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">true</property>
+                <property name="title" translatable="yes" context="shortcut window">Preferences</property>
+                <property name="action-name">app.prefs</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">true</property>
+                <property name="title" translatable="yes" context="shortcut window">Keyboard shortcuts</property>
+                <property name="action-name">win.show-help-overlay</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">true</property>
+                <property name="title" translatable="yes" context="shortcut window">Quit</property>
+                <property name="action-name">app.quit</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/data/ui/titlebar_menu.ui
+++ b/data/ui/titlebar_menu.ui
@@ -25,6 +25,10 @@
         <attribute name="label" translatable="yes">_Help</attribute>
       </item>
       <item>
+        <attribute name="action">win.show-help-overlay</attribute>
+        <attribute name="label" translatable="yes">_Keyboard Shortcuts</attribute>
+      </item>
+      <item>
         <attribute name="action">app.about</attribute>
         <attribute name="label" translatable="yes">_About</attribute>
       </item>

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -30,6 +30,7 @@ data/ui/delete_book_dialog.ui
 data/ui/error_reporting.ui
 data/ui/file_not_found.ui
 data/ui/headerbar.ui
+data/ui/help_overlay.ui
 data/ui/import_failed.ui
 data/ui/main_window.ui
 data/ui/media_controller.ui


### PR DESCRIPTION
Sorry I didn't split my merge request. 

This patches contains two things.

application: Add shortcut for Help
- To comply GNOME HIG add shortcut for Help. Source: https://developer.gnome.org/hig/reference/keyboard.html

application: Implement Help Overlay
- Help Overlay is GNOME's keyboard shortcuts page. It only lists usable shortcuts, and implementing this future is very easy
