### PR TITLE
Fix "invalid version" crash on startup

### DIFF
--- a/cozy/ui/widgets/whats_new_window.py
+++ b/cozy/ui/widgets/whats_new_window.py
@@ -56,11 +56,7 @@ class WhatsNewWindow(Handy.Window):
         except version.InvalidVersion:
             self._fill_welcome()
         else:
-            if type(last_launched_version) is version.LegacyVersion:
-                self._fill_welcome()
-            else:
-                self._fill_whats_new(last_launched_version)
-
+            self._fill_whats_new(last_launched_version)
 
     def _fill_welcome(self):
         from cozy.ui.widgets.welcome import Welcome

--- a/cozy/ui/widgets/whats_new_window.py
+++ b/cozy/ui/widgets/whats_new_window.py
@@ -51,12 +51,16 @@ class WhatsNewWindow(Handy.Window):
     def _fill_window(self):
         self.children = []
 
-        last_launched_version = version.parse(self.app_settings.last_launched_version)
-
-        if type(last_launched_version) is version.LegacyVersion:
+        try:
+            last_launched_version = version.parse(self.app_settings.last_launched_version)
+        except version.InvalidVersion:
             self._fill_welcome()
         else:
-            self._fill_whats_new(last_launched_version)
+            if type(last_launched_version) is version.LegacyVersion:
+                self._fill_welcome()
+            else:
+                self._fill_whats_new(last_launched_version)
+
 
     def _fill_welcome(self):
         from cozy.ui.widgets.welcome import Welcome


### PR DESCRIPTION
This commit fixes the program crashing because of an uncaught exception. The bug was triggered by `app_settings.last_launched_version` being unset - which would always be the case when launching the program for the first time.

The bug can also be triggered by manually changing the setting to an invalid value - e.g. by running:
```
$ gsettings set com.github.geigi.cozy last-launched-version 'ayy lmao'
```

Fixes issue #756.