### PR TITLE
workflows/*: bump version, fix warnings

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
       
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       image: ghcr.io/geigi/cozy-ci:main
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/flathub.yml
+++ b/.github/workflows/flathub.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
       
     - name: Install dependencies
       run: |

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Set up QEMU
       id: qemu
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
       with:
         platforms: arm64
       if: ${{ matrix.arch == 'aarch64' }}

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-41
+      image: bilelmoussaoui/flatpak-github-actions:gnome-44
       options: --privileged
 
     strategy:
@@ -16,7 +16,7 @@ jobs:
       # Don't fail the whole workflow if one architecture fails
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install deps
       run: |
@@ -30,7 +30,7 @@ jobs:
         platforms: arm64
       if: ${{ matrix.arch == 'aarch64' }}
 
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
       with:
         bundle: Cozy.flatpak
         manifest-path: com.github.geigi.cozy.json

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Changes

- Bump the `actions/checkout` version to v3 throughout all workflows. [This fixes the Node 12 deprecation warnings displayed under the Annotations section in Actions, as newer versions of it use Node 16]
- Fix missing eol in all workflow files.
- Under `flatpak.yml`, bump
  - The `flatpak-builder` version to the latest version `v6`.
  - Update container image to GNOME 44.
  - `docker/setup-qemu-action` to `v2`. [This fixes the Node 12 deprecation warnings displayed under the Annotations section in Actions, as newer versions of it use Node 16]

## Testing

All the above changes have been tested in my fork before creating a PR, the action runs can be found here https://github.com/kbdharun/cozy/actions.

## Notes

As expected, the aarch runners will take extra time as it is not supported by GitHub Actions [which only have x86_64 runners] flatpak builder works around this using qemu which leads to longer workflow times, fortunately, GitHub seems to be working on ARM runners in the near future (https://github.com/actions/runner-images/issues/5631) so let us hope for the best. 