### PR TITLE
MPRIS: Fix seek actions to correctly move the specified amount of time

### DIFF
--- a/cozy/control/mpris.py
+++ b/cozy/control/mpris.py
@@ -228,7 +228,12 @@ class MPRIS(Server):
         self._player.position = position * 10**3
 
     def Seek(self, offset):
-        self._player.position = self._player.position + offset * 10**3
+        # convert milliseconds to seconds
+        offset_sec=offset / 10**6
+        if offset_sec > 0:
+            self._player.forward(offset_sec)
+        elif offset_sec < 0:
+            self._player.rewind(-offset_sec)
 
     def Seeked(self, position):
         self.__bus.emit_signal(


### PR DESCRIPTION
Hello!
This fixes the issue where MPRIS seek calls would cause cozy to skip ahead to the next chapter #781 
Found that there was another function that basically already did what was needed for seeking in MPRIS, and thus co-opted and modified it to work for both purposes.

Perhaps it would be better to chase why self._player.position returns seemingly random numbers. However, it seemed more prudent to just reuse existing code for this purpose.

Let me know your thoughts, happy to throw this away and go a different direction.
(Disclaimer: I'm a newbie to contributing to open source)