### PR TITLE
data: Mark release descriptions as untranslatable

### DIFF
--- a/data/com.github.geigi.cozy.appdata.xml
+++ b/data/com.github.geigi.cozy.appdata.xml
@@ -54,7 +54,7 @@
   </custom>
   <releases>
     <release version="1.2.1" timestamp="1661086733">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Support for GTK style manager (thanks A6GibKm)</li>
           <li>Use natural sorting for chapter titles</li>
@@ -63,7 +63,7 @@
       </description>
     </release>
     <release version="1.2.0" timestamp="1641661352">
-      <description>
+      <description translatable="no">
         <p>
         This release features a redesigned preference window. All settings can now be searched. Good news for mobile users too: the redesign should work a lot better on mobile devices now.
         </p>
@@ -78,7 +78,7 @@
       </description>
     </release>
     <release version="1.1.3" timestamp="1640949259">
-      <description>
+      <description translatable="no">
         <p>
         A small bugfix release which makes Cozy more reliable.
         </p>
@@ -91,7 +91,7 @@
       </description>
     </release>
     <release version="1.1.2" timestamp="1629458444">
-      <description>
+      <description translatable="no">
         <p>
         A small bugfix release which makes Cozy more reliable.
         </p>
@@ -107,7 +107,7 @@
       </description>
     </release>
     <release version="1.1.1" timestamp="1629456144">
-      <description>
+      <description translatable="no">
         <p>
         A small bugfix release which makes Cozy more reliable.
         </p>
@@ -123,7 +123,7 @@
       </description>
     </release>
     <release version="1.1.0" timestamp="1628322225">
-      <description>
+      <description translatable="no">
         <p>
         This release features a redesigned library with responsiveness in mind.
         </p>
@@ -140,7 +140,7 @@
       </description>
     </release>
     <release version="1.0.4" timestamp="1627489551">
-      <description>
+      <description translatable="no">
         <p>
         Performance improvements for the book detail view and some bugfixes.
         </p>
@@ -155,7 +155,7 @@
       </description>
     </release>
     <release version="1.0.3" timestamp="1622826417">
-      <description>
+      <description translatable="no">
         <p>
         A small bugfix release which makes Cozy more reliable.
         </p>
@@ -170,7 +170,7 @@
       </description>
     </release>
     <release version="1.0.2" timestamp="1622490608">
-      <description>
+      <description translatable="no">
         <p>
         A small bugfix release which makes Cozy more reliable.
         </p>
@@ -185,7 +185,7 @@
       </description>
     </release>
     <release version="1.0.1" timestamp="1622363623">
-      <description>
+      <description translatable="no">
         <p>
         This release features chapter support for m4b files.
         </p>
@@ -199,7 +199,7 @@
       </description>
     </release>
     <release version="1.0.0" timestamp="1622358236">
-      <description>
+      <description translatable="no">
         <p>
         This release features chapter support for m4b files.
         </p>


### PR DESCRIPTION
GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.