### PR TITLE
appdata: add vcs-browser support

### DIFF
--- a/data/com.github.geigi.cozy.appdata.xml
+++ b/data/com.github.geigi.cozy.appdata.xml
@@ -47,6 +47,7 @@
   <url type="bugtracker">https://github.com/geigi/cozy/issues</url>
   <url type="help">https://github.com/geigi/cozy/issues</url>
   <url type="donation">https://www.patreon.com/geigi</url>
+  <url type="vcs-browser">https://github.com/geigi/cozy/</url>
   <update_contact>cozy@geigi.de</update_contact>
   <custom>
     <value key="Purism::form_factor">workstation</value>


### PR DESCRIPTION
These URL is visible on Flathub and GNOME Control Center.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url