### PR TITLE
appdata: Remove Purism metadata

### DIFF
--- a/data/com.github.geigi.cozy.appdata.xml
+++ b/data/com.github.geigi.cozy.appdata.xml
@@ -48,10 +48,6 @@
   <url type="help">https://github.com/geigi/cozy/issues</url>
   <url type="donation">https://www.patreon.com/geigi</url>
   <update_contact>cozy@geigi.de</update_contact>
-  <custom>
-    <value key="Purism::form_factor">workstation</value>
-    <value key="Purism::form_factor">mobile</value>
-  </custom>
   <releases>
     <release version="1.2.1" timestamp="1661086733">
       <description>


### PR DESCRIPTION
This metadata is invalid: custom data is a dictionary and using the same key multiple times in a dictionary does not work

More information: https://github.com/ximion/appstream/issues/476