### PR TITLE
chore/ci: update workflows

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,12 @@ on: [push, pull_request]
 jobs:
   test:
 
-    runs-on: ubuntu-20.04
-
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/geigi/cozy-ci:main
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/flathub.yml
+++ b/.github/workflows/flathub.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       
     - name: Install dependencies
       run: |

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -5,9 +5,8 @@ on: [push, pull_request]
 jobs:
   flatpak:
     runs-on: ubuntu-latest
-
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-44
+      image: bilelmoussaoui/flatpak-github-actions:gnome-45
       options: --privileged
 
     strategy:
@@ -25,7 +24,7 @@ jobs:
 
     - name: Set up QEMU
       id: qemu
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: arm64
       if: ${{ matrix.arch == 'aarch64' }}

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Changes

- Bump the `actions/checkout` version from `v3` (Node 18) to `v4` (Node 20).
- Update runner across all workflows to `ubuntu-latest` (Ubuntu 22.04).
- Update `bilelmoussaoui/flatpak-github-actions` tag to GNOME 45.
- Bump `docker/setup-qemu-action` to `v3`.
- Minor fixes in spacing.