### PR TITLE
Remove unused `_get_file_count_in_dir` method

### DIFF
--- a/cozy/media/importer.py
+++ b/cozy/media/importer.py
@@ -204,6 +204,3 @@ class Importer(EventSender):
                 continue
 
             yield file
-
-    def _get_file_count_in_dir(self, dir):
-        len([name for name in os.listdir(dir) if os.path.isfile(name)])


### PR DESCRIPTION
It was introduced in b39924a3ea5e5573285e5e84122b32754d19474f, but I cannot find any callers of it.