### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/com.github.geigi.cozy.json
+++ b/com.github.geigi.cozy.json
@@ -133,6 +133,7 @@
     {
       "name": "cozy",
       "buildsystem": "meson",
+      "run-tests": true,
       "sources": [
         {
           "type": "dir",

--- a/data/com.github.geigi.cozy.appdata.xml
+++ b/data/com.github.geigi.cozy.appdata.xml
@@ -44,7 +44,11 @@
       <image>https://raw.githubusercontent.com/geigi/cozy/img/img/screenshot4.png</image>
     </screenshot>
   </screenshots>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Julian Geywitz</developer_name>
+  <developer id="github.com">
+      <name translatable="no">Julian Geywitz</name>
+  </developer>
   <url type="homepage">https://cozy.sh</url>
   <url type="bugtracker">https://github.com/geigi/cozy/issues</url>
   <url type="help">https://matrix.to/#/#cozy:gnome.org?via=matrix.org&amp;via=gnome.org</url>

--- a/data/com.github.geigi.cozy.appdata.xml
+++ b/data/com.github.geigi.cozy.appdata.xml
@@ -220,37 +220,8 @@
       </description>
     </release>
   </releases>
-  
-  <content_rating type="oars-1.1">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="violence-desecration">none</content_attribute>
-    <content_attribute id="violence-slavery">none</content_attribute>
-    <content_attribute id="violence-worship">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
-    <content_attribute id="sex-homosexuality">none</content_attribute>
-    <content_attribute id="sex-prostitution">none</content_attribute>
-    <content_attribute id="sex-adultery">none</content_attribute>
-    <content_attribute id="sex-appearance">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
-    <content_attribute id="social-chat">none</content_attribute>
-    <content_attribute id="social-info">none</content_attribute>
-    <content_attribute id="social-audio">none</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
-    <content_attribute id="social-contacts">none</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
-  </content_rating>
-  
+
+  <content_rating type="oars-1.1" />
   <custom>
     <value key="x-appcenter-color-primary">#FB6542</value>
     <value key="x-appcenter-color-primary-text">#FFFFFF</value>

--- a/data/meson.build
+++ b/data/meson.build
@@ -41,6 +41,7 @@ appstream_file = i18n.merge_file(
 appstreamcli = find_program('appstreamcli', required: false)
 if appstreamcli.found()
   test('Validate appstream file', appstreamcli,
-    args: ['validate', '--no-net', appstream_file]
+    args: ['validate', '--no-net', '--explain', appstream_file],
+    workdir: meson.current_build_dir()
   )
 endif


### PR DESCRIPTION
### appdata: Improve appdata for AppStream 1.0

- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Improve appstreamcli parameters

### appdata: Remove none OARS tags

"The old generator also included all the none-value entries—it
no longer does this, you can safely remove them.

If it only consists of none values, it’s safe to shorten it to just:
`<content_rating type="oars-1.1" />`"

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#oars-information