### PR TITLE
chore: automate dep updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Changes

This PR adds a `dependabot.yml` config file to automate dependency updates for the GitHub actions (version) and the Python `requirements.txt` file.

Dependabot is a [built-in security feature](https://docs.github.com/en/code-security/dependabot) in GitHub, it automatically opens PRs to update dependencies if there are moderate or high severity CVEs attached to an action/dependency (if it is enabled in https://github.com/geigi/cozy/security), this PR adds support for normal version updates (monthly) using dependabot for the dependencies. (In future, manual updates like #808 aren't necessary for the actions)

---

**Offtopic**: I noticed there are travis CI files in the repo, is it still being used (now that testing and releases are done via GitHub actions).