### PR TITLE
Fix seekbar jumping when changing playback speed

### DIFF
--- a/cozy/media/player.py
+++ b/cozy/media/player.py
@@ -24,7 +24,6 @@ log = logging.getLogger("mediaplayer")
 
 US_TO_SEC = 10 ** 6
 NS_TO_SEC = 10 ** 9
-REWIND_SECONDS = 30
 
 
 class Player(EventSender):

--- a/cozy/ui/media_controller.py
+++ b/cozy/ui/media_controller.py
@@ -116,7 +116,7 @@ class MediaController(Adw.BreakpointBin):
             self.play_button.set_icon_name("media-playback-start-symbolic")
 
     def _on_position_changed(self):
-        position = self._playback_control_view_model.position
+        position = self._playback_control_view_model.relative_position
         if position is not None:
             self.seek_bar.position = position
 
@@ -154,4 +154,4 @@ class MediaController(Adw.BreakpointBin):
         self._playback_control_view_model.volume = volume
 
     def _on_seek_bar_position_changed(self, _, position):
-        self._playback_control_view_model.position = position
+        self._playback_control_view_model.relative_position = position

--- a/cozy/ui/media_controller.py
+++ b/cozy/ui/media_controller.py
@@ -71,15 +71,17 @@ class MediaController(Adw.BreakpointBin):
 
     def _connect_widgets(self):
         self.play_button.connect("clicked", self._play_clicked)
-        self.prev_button.connect("clicked", self._rewind_clicked)
-        self.next_button.connect("clicked", self._forward_clicked)
         self.volume_button.connect("value-changed", self._on_volume_button_changed)
         self.seek_bar.connect("position-changed", self._on_seek_bar_position_changed)
 
-        self._cover_img_gesture = Gtk.GestureClick()
-        self._cover_img_gesture.connect("pressed", self._cover_clicked)
-        self.cover_img.add_controller(self._cover_img_gesture)
+        self.prev_button.connect("clicked", self._rewind_clicked)
+        self.next_button.connect("clicked", self._forward_clicked)
+        self.seek_bar.connect("rewind", self._rewind_clicked)
+        self.seek_bar.connect("forward", self._forward_clicked)
 
+        cover_click_gesture = Gtk.GestureClick()
+        cover_click_gesture.connect("pressed", self._cover_clicked)
+        self.cover_img.add_controller(cover_click_gesture)
         self.cover_img.set_cursor(Gdk.Cursor.new_from_name("pointer"))
 
     def _set_cover_image(self, book: Book):

--- a/cozy/ui/widgets/playback_speed_popover.py
+++ b/cozy/ui/widgets/playback_speed_popover.py
@@ -20,11 +20,9 @@ class PlaybackSpeedPopover(Gtk.Popover):
         self.playback_speed_scale.set_increments(0.02, 0.05)
         self.playback_speed_scale.connect("value-changed", self._on_playback_speed_scale_changed)
 
-        self._connect_view_model()
-        self._on_playback_speed_changed()
-
-    def _connect_view_model(self):
         self._view_model.bind_to("playback_speed", self._on_playback_speed_changed)
+
+        self._on_playback_speed_changed()
 
     def _on_playback_speed_scale_changed(self, _):
         speed = round(self.playback_speed_scale.get_value(), 2)

--- a/cozy/ui/widgets/seek_bar.py
+++ b/cozy/ui/widgets/seek_bar.py
@@ -63,10 +63,8 @@ class SeekBar(Gtk.Box):
         position = int(total * self.progress_scale.get_value() / 100)
         remaining_secs = int(total - position)
 
-        current_text = seconds_to_str(position, total)
-        remaining_text = seconds_to_str(remaining_secs, total)
-        self.current_label.set_markup("<span font_features='tnum'>" + current_text + "</span>")
-        self.remaining_label.set_markup("<span font_features='tnum'>-" + remaining_text + "</span>")
+        self.current_label.set_text(seconds_to_str(position, total))
+        self.remaining_label.set_text(seconds_to_str(remaining_secs, total))
 
     def _on_progress_scale_release(self, *_):
         self._progress_scale_pressed = False

--- a/cozy/ui/widgets/seek_bar.py
+++ b/cozy/ui/widgets/seek_bar.py
@@ -75,11 +75,9 @@ class SeekBar(Gtk.Box):
 
     def _on_progress_key_pressed(self, _, event, *__):
         if event in {Gdk.KEY_Up, Gdk.KEY_Left}:
-            self.position = max(self.position - 30, 0)
+            self.emit("rewind")
         elif event in {Gdk.KEY_Down, Gdk.KEY_Right}:
-            self.position = min(self.position + 30, 100)
-
-        self.emit("position-changed", self.position)
+            self.emit("forward")
 
     def _on_progress_scale_press(self, *_):
         self._progress_scale_pressed = True
@@ -88,3 +86,6 @@ class SeekBar(Gtk.Box):
 
 GObject.signal_new('position-changed', SeekBar, GObject.SIGNAL_RUN_LAST, GObject.TYPE_PYOBJECT,
                    (GObject.TYPE_PYOBJECT,))
+
+GObject.signal_new('rewind', SeekBar, GObject.SIGNAL_RUN_LAST, GObject.TYPE_PYOBJECT, ())
+GObject.signal_new('forward', SeekBar, GObject.SIGNAL_RUN_LAST, GObject.TYPE_PYOBJECT, ())

--- a/cozy/ui/widgets/seek_bar.py
+++ b/cozy/ui/widgets/seek_bar.py
@@ -12,11 +12,12 @@ class SeekBar(Gtk.Box):
     remaining_label: Gtk.Label = Gtk.Template.Child()
     remaining_event_box: Gtk.Box = Gtk.Template.Child()
 
+    length: float
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        self.length = 0
-
+        self.length: float = 0.0
         self._progress_scale_pressed = False
 
         self.progress_scale.connect("value-changed", self._on_progress_scale_changed)

--- a/cozy/ui/widgets/seek_bar.py
+++ b/cozy/ui/widgets/seek_bar.py
@@ -59,10 +59,10 @@ class SeekBar(Gtk.Box):
         self.remaining_event_box.set_visible(value)
 
     def _on_progress_scale_changed(self, _):
-        position = int(self.progress_scale.get_value())
         total = self.length
+        position = int(total * self.progress_scale.get_value() / 100)
+        remaining_secs = int(total - position)
 
-        remaining_secs: int = int(total - position)
         current_text = seconds_to_str(position, total)
         remaining_text = seconds_to_str(remaining_secs, total)
         self.current_label.set_markup("<span font_features='tnum'>" + current_text + "</span>")

--- a/cozy/view_model/playback_control_view_model.py
+++ b/cozy/view_model/playback_control_view_model.py
@@ -69,6 +69,23 @@ class PlaybackControlViewModel(Observable, EventSender):
         return self._player.loaded_book.current_chapter.length / self._book.playback_speed
 
     @property
+    def relative_position(self) -> float | None:
+        if not self._player.loaded_book or not self._book:
+            return None
+
+        position = self._book.current_chapter.position - self._book.current_chapter.start_position
+        length = self._player.loaded_book.current_chapter.length
+        return position / NS_TO_SEC / length * 100
+
+    @relative_position.setter
+    def relative_position(self, new_value: float) -> None:
+        if not self._book:
+            return
+
+        length = self._player.loaded_book.current_chapter.length
+        self._player.position = new_value / 100 * length * self._book.playback_speed
+
+    @property
     def lock_ui(self) -> bool:
         return not self._book
 

--- a/cozy/view_model/playback_control_view_model.py
+++ b/cozy/view_model/playback_control_view_model.py
@@ -30,13 +30,7 @@ class PlaybackControlViewModel(Observable, EventSender):
 
     @book.setter
     def book(self, value: Optional[Book]):
-        if self._book:
-            self._book.remove_bind("playback_speed", self._on_playback_speed_changed)
-
         self._book = value
-        if value:
-            self._book.bind_to("playback_speed", self._on_playback_speed_changed)
-
         self._notify("lock_ui")
 
     @property

--- a/cozy/view_model/playback_control_view_model.py
+++ b/cozy/view_model/playback_control_view_model.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from cozy.architecture.event_sender import EventSender
 from cozy.architecture.observable import Observable
 from cozy.ext import inject
@@ -17,7 +15,7 @@ class PlaybackControlViewModel(Observable, EventSender):
         super().__init__()
         super(Observable, self).__init__()
 
-        self._book: Optional[Book] = None
+        self._book: Book | None = None
 
         self._player.add_listener(self._on_player_event)
 
@@ -25,11 +23,11 @@ class PlaybackControlViewModel(Observable, EventSender):
             self.book = self._player.loaded_book
 
     @property
-    def book(self) -> Optional[Book]:
+    def book(self) -> Book | None:
         return self._book
 
     @book.setter
-    def book(self, value: Optional[Book]):
+    def book(self, value: Book | None):
         self._book = value
         self._notify("lock_ui")
 
@@ -41,7 +39,7 @@ class PlaybackControlViewModel(Observable, EventSender):
         return self._player.playing
 
     @property
-    def position(self) -> Optional[float]:
+    def position(self) -> float | None:
         if not self._book:
             return None
 
@@ -56,7 +54,7 @@ class PlaybackControlViewModel(Observable, EventSender):
         self._player.position = new_value * self._book.playback_speed
 
     @property
-    def length(self) -> Optional[float]:
+    def length(self) -> float | None:
         if not self._player.loaded_book or not self._book:
             return None
 

--- a/data/ui/seek_bar.ui
+++ b/data/ui/seek_bar.ui
@@ -15,12 +15,14 @@
         <property name="tooltip-text" translatable="true">Elapsed time</property>
         <property name="halign">end</property>
         <property name="valign">center</property>
-        <property name="label">&lt;span font_features=&apos;tnum&apos;&gt;--:--&lt;/span&gt;</property>
-        <property name="use-markup">true</property>
+        <property name="label">--:--</property>
         <property name="single-line-mode">true</property>
         <accessibility>
           <property name="label" translatable="true">Elapsed time of current part</property>
         </accessibility>
+        <style>
+          <class name="numeric"/>
+        </style>
       </object>
     </child>
     <child>
@@ -46,12 +48,14 @@
           <object class="GtkLabel" id="remaining_label">
             <property name="tooltip-text" translatable="true">Remaining time</property>
             <property name="halign">start</property>
-            <property name="label">&lt;span font_features=&apos;tnum&apos;&gt;--:--&lt;/span&gt;</property>
-            <property name="use-markup">true</property>
+            <property name="label">--:--</property>
             <property name="single-line-mode">true</property>
             <accessibility>
               <property name="label" translatable="true">Remaining time of current part</property>
             </accessibility>
+            <style>
+              <class name="numeric"/>
+            </style>
           </object>
         </child>
       </object>


### PR DESCRIPTION
Fixes the two bugs mentioned in #769, and fixes the incorrect behavior when seeking with keyboard, where the 30 seconds were hard-coded, and it didn't follow the durations set in the settings.


Fixes #769