### PR TITLE
New branding colors, that look actually good

### DIFF
--- a/data/com.github.geigi.cozy.appdata.xml
+++ b/data/com.github.geigi.cozy.appdata.xml
@@ -241,8 +241,8 @@
     <display_length compare="gt">360</display_length>
   </recommends>
   <branding>
-    <color type="primary" scheme_preference="light">#ffa348</color>
-    <color type="primary" scheme_preference="dark">#ffa348</color>
+    <color type="primary" scheme_preference="light">#ffbe6f</color>
+    <color type="primary" scheme_preference="dark">#39314e</color>
   </branding>
   <custom>
     <value key="x-appcenter-suggested-price">2</value>

--- a/data/com.github.geigi.cozy.appdata.xml
+++ b/data/com.github.geigi.cozy.appdata.xml
@@ -242,7 +242,7 @@
   </recommends>
   <branding>
     <color type="primary" scheme_preference="light">#ffbe6f</color>
-    <color type="primary" scheme_preference="dark">#39314e</color>
+    <color type="primary" scheme_preference="dark">#6a451f</color>
   </branding>
   <custom>
     <value key="x-appcenter-suggested-price">2</value>


### PR DESCRIPTION
New branding colors, that look actually good. The dark orange is washed-out a bit, but we can't just go with generic purple.

Fixes #894 

![rect1](https://github.com/geigi/cozy/assets/77941087/dd23730a-a336-4c39-955e-4eac02520af3)
