### PR TITLE
Appdata related changes

### DIFF
--- a/data/com.github.geigi.cozy.appdata.xml
+++ b/data/com.github.geigi.cozy.appdata.xml
@@ -7,8 +7,8 @@
   <launchable type="desktop-id">com.github.geigi.cozy.desktop</launchable>
   <translation type="gettext">com.github.geigi.cozy</translation>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer id="github.com">
   <developer_name translate="no">Julian Geywitz</developer_name>
+  <developer id="sh.cozy">
     <name translate="no">Julian Geywitz</name>
   </developer>
   <update_contact>cozy@geigi.de</update_contact>

--- a/data/com.github.geigi.cozy.appdata.xml
+++ b/data/com.github.geigi.cozy.appdata.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>com.github.geigi.cozy</id>
-  <name translatable="no">Cozy</name>
+  <name translate="no">Cozy</name>
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <launchable type="desktop-id">com.github.geigi.cozy.desktop</launchable>
   <translation type="gettext">com.github.geigi.cozy</translation>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">Julian Geywitz</developer_name>
   <developer id="github.com">
-    <name translatable="no">Julian Geywitz</name>
+  <developer_name translate="no">Julian Geywitz</developer_name>
+    <name translate="no">Julian Geywitz</name>
   </developer>
   <update_contact>cozy@geigi.de</update_contact>
   <summary>Listen to audio books</summary>
@@ -49,7 +49,7 @@
   </screenshots>
   <releases>
     <release version="1.3.0" date="2024-03-01">
-      <description translatable="no">
+      <description translate="no">
         <p>
           After almost two years, a new version of Cozy is finally here! This release brings an updated user interface along with numerous bug fixes and improved performance.
         </p>
@@ -67,7 +67,7 @@
       </description>
     </release>
     <release version="1.2.1" date="2022-08-21">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Support for GTK style manager (thanks A6GibKm)</li>
           <li>Use natural sorting for chapter titles</li>
@@ -76,7 +76,7 @@
       </description>
     </release>
     <release version="1.2.0" date="2022-01-08">
-      <description translatable="no">
+      <description translate="no">
         <p>
         This release features a redesigned preference window. All settings can now be searched. Good news for mobile users too: the redesign should work a lot better on mobile devices now.
         </p>
@@ -91,7 +91,7 @@
       </description>
     </release>
     <release version="1.1.3" date="2021-12-31">
-      <description translatable="no">
+      <description translate="no">
         <p>
         A small bugfix release which makes Cozy more reliable.
         </p>
@@ -104,7 +104,7 @@
       </description>
     </release>
     <release version="1.1.2" date="2021-08-20">
-      <description translatable="no">
+      <description translate="no">
         <p>
         A small bugfix release which makes Cozy more reliable.
         </p>
@@ -120,7 +120,7 @@
       </description>
     </release>
     <release version="1.1.1" date="2021-08-20">
-      <description translatable="no">
+      <description translate="no">
         <p>
         A small bugfix release which makes Cozy more reliable.
         </p>
@@ -136,7 +136,7 @@
       </description>
     </release>
     <release version="1.1.0" date="2021-08-07">
-      <description translatable="no">
+      <description translate="no">
         <p>
         This release features a redesigned library with responsiveness in mind.
         </p>
@@ -153,7 +153,7 @@
       </description>
     </release>
     <release version="1.0.4" date="2021-07-28">
-      <description translatable="no">
+      <description translate="no">
         <p>
         Performance improvements for the book detail view and some bugfixes.
         </p>
@@ -168,7 +168,7 @@
       </description>
     </release>
     <release version="1.0.3" date="2021-06-04">
-      <description translatable="no">
+      <description translate="no">
         <p>
         A small bugfix release which makes Cozy more reliable.
         </p>
@@ -183,7 +183,7 @@
       </description>
     </release>
     <release version="1.0.2" date="2021-05-31">
-      <description translatable="no">
+      <description translate="no">
         <p>
         A small bugfix release which makes Cozy more reliable.
         </p>
@@ -198,7 +198,7 @@
       </description>
     </release>
     <release version="1.0.1" date="2021-05-30">
-      <description translatable="no">
+      <description translate="no">
         <p>
         This release features chapter support for m4b files.
         </p>
@@ -212,7 +212,7 @@
       </description>
     </release>
     <release version="1.0.0" date="2021-05-30">
-      <description translatable="no">
+      <description translate="no">
         <p>
         This release features chapter support for m4b files.
         </p>


### PR DESCRIPTION
### appdata: `translate=no` properties

It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: `https://github.com/ximion/appstream/issues/623`

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Update developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness. 

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer