### PR TITLE
UI String Improvements

### DIFF
--- a/cozy/ui/delete_book_view.py
+++ b/cozy/ui/delete_book_view.py
@@ -10,14 +10,14 @@ class DeleteBookView(Adw.AlertDialog):
 
     def __init__(self, callback, book: Book):
         super().__init__(
-            heading=_("Delete Audiobook?"),
-            body=_("The audiobook will be removed from your disk and from Cozy's library."),
+            heading=_("Permanently Delete Audiobook?"),
+            body=_("The audiobook will be permanently deleted from your device and cannot be recovered"),
             default_response="cancel",
             close_response="cancel",
         )
 
         self.add_response("cancel", _("Cancel"))
-        self.add_response("delete", _("Remove Audiobook"))
+        self.add_response("delete", _("Delete"))
         self.set_response_appearance("delete", Adw.ResponseAppearance.DESTRUCTIVE)
 
         list_box = Gtk.ListBox(margin_top=12, css_classes=["boxed-list"])

--- a/cozy/ui/file_not_found_dialog.py
+++ b/cozy/ui/file_not_found_dialog.py
@@ -15,7 +15,7 @@ class FileNotFoundDialog(Adw.AlertDialog):
         self.missing_chapter = chapter
 
         super().__init__(
-            heading=_("File not found"),
+            heading=_("File Not Found"),
             body=_("This file could not be found. Do you want to locate it manually?"),
             default_response="locate",
             close_response="cancel",

--- a/cozy/ui/widgets/book_element.py
+++ b/cozy/ui/widgets/book_element.py
@@ -67,10 +67,10 @@ class BookElement(Gtk.FlowBoxChild):
         menu_model = Gio.Menu()
 
         self.install_action("book_element.mark_as_read", None, self._mark_as_read)
-        menu_model.append(_("Mark as read"), "book_element.mark_as_read")
+        menu_model.append(_("Mark as Read"), "book_element.mark_as_read")
 
         self.install_action("book_element.jump_to_folder", None, self._jump_to_folder)
-        menu_model.append(_("Open in file browser"), "book_element.jump_to_folder")
+        menu_model.append(_("Open in File Browser"), "book_element.jump_to_folder")
 
         self.install_action("book_element.remove_book", None, self._remove_book)
         menu_model.append(_("Permanently Delete…"), "book_element.remove_book")

--- a/cozy/ui/widgets/book_element.py
+++ b/cozy/ui/widgets/book_element.py
@@ -73,7 +73,7 @@ class BookElement(Gtk.FlowBoxChild):
         menu_model.append(_("Open in file browser"), "book_element.jump_to_folder")
 
         self.install_action("book_element.remove_book", None, self._remove_book)
-        menu_model.append(_("Remove from library"), "book_element.remove_book")
+        menu_model.append(_("Permanently Delete…"), "book_element.remove_book")
 
         menu = Gtk.PopoverMenu(menu_model=menu_model, has_arrow=False)
         menu.set_parent(self.art)

--- a/data/ui/main_window.blp
+++ b/data/ui/main_window.blp
@@ -193,7 +193,7 @@ Adw.ApplicationWindow app_window {
               }
 
               Adw.NavigationPage {
-                title: _("Book title");
+                title: _("Book Title");
                 tag: 'book_overview';
 
                 child: Adw.ToolbarView book_details_container {};

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -108,7 +108,7 @@ template $PreferencesWindow: Adw.PreferencesDialog {
     title: _("Feedback");
 
     Adw.PreferencesGroup user_feedback_preference_group {
-      title: _("User feedback");
+      title: _("User Feedback");
     }
   }
 }

--- a/data/ui/search_page.blp
+++ b/data/ui/search_page.blp
@@ -4,12 +4,12 @@ using Adw 1;
 template $SearchView: Adw.Bin {
   Stack stack {
     Adw.StatusPage start_searching_page {
-      title: _("Search in your library");
+      title: _("Search in Your Library");
       icon-name: 'library-symbolic';
     }
 
     Adw.StatusPage nothing_found_page {
-      title: _("No results found");
+      title: _("No Results Found");
       icon-name: 'edit-find-symbolic';
     }
 

--- a/data/ui/storage_locations.blp
+++ b/data/ui/storage_locations.blp
@@ -2,7 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 template $StorageLocations: Adw.PreferencesGroup {
-  title: _("Storage locations");
+  title: _("Storage Locations");
 
   ListBox storage_locations_list {
     margin-bottom: 18;


### PR DESCRIPTION
### ui: Improve remove strings

Change the 'Remove from library' strings to 'Permanently delete' to make the action clearer for the user, informing them that the action will delete user files and cannot be undone.

Fixes #912 

### ui: Make some strings GNOME HIG compatible

Use header capitalization for menu entries and titles.

More information: https://developer.gnome.org/hig/guidelines/writing-style.html