### PR TITLE
Fix an annoying bug where not all books from a storage location were removed

### DIFF
--- a/cozy/view_model/storages_view_model.py
+++ b/cozy/view_model/storages_view_model.py
@@ -95,17 +95,17 @@ class StoragesViewModel(Observable, EventSender):
         if model.default:
             return
 
+        storage_path = model.path
+        chapters_to_remove = []
+
+        for book in self._library.books:
+            chapters_to_remove.extend([c for c in book.chapters if c.file.startswith(storage_path)])
+
+        for chapter in set(chapters_to_remove):
+            chapter.delete()
+
         model.delete()
         self._model.invalidate()
-
-        storage_path = str(model.path)
-        for book in self._library.books:
-            chapters_to_remove = [
-                c for c in book.chapters if c.file.startswith(storage_path)
-            ]
-
-            for chapter in chapters_to_remove:
-                chapter.delete()
 
         self.emit_event("storage-removed", model)
         self._notify("storage_locations")


### PR DESCRIPTION
This was some kind of a race condition, caused by weird tagging across audiobooks in the same storage location.