### PR TITLE
Update ruff CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: nkarasiak/ruff-action@v2
         with:
           args: --output-format github


### PR DESCRIPTION
The original GH Action isn't compatible with Ruff 0.5.0, and unfortunately it can't be updated due to legal bullshit.