### PR TITLE
Delay saving settings until closing the app

### DIFF
--- a/cozy/application_settings.py
+++ b/cozy/application_settings.py
@@ -9,6 +9,7 @@ class ApplicationSettings(EventSender):
 
     def __init__(self):
         super().__init__()
+        self._settings.delay()
         self._connect()
 
     def _connect(self):


### PR DESCRIPTION
This radically improves the performance of resizing the window, as it no longer has to save the three updated values on every resize signal. The volume slider is also smoother now.