### PR TITLE
Add common keyboard controls

### DIFF
--- a/cozy/media/player.py
+++ b/cozy/media/player.py
@@ -455,6 +455,12 @@ class Player(EventSender):
         if state == Gst.State.PLAYING:
             self._gst_player.play()
 
+    def volume_up(self):
+        self.volume = min(1.0, self.volume + 0.1)
+
+    def volume_down(self):
+        self.volume = max(0, self.volume - 0.1)
+
     def destroy(self):
         self._gst_player.stop()
 

--- a/cozy/media/player.py
+++ b/cozy/media/player.py
@@ -601,7 +601,7 @@ class Player(EventSender):
 
         self._book.current_chapter.position = self._book.current_chapter.start_position
         print('index', index_current_chapter)
-        if 0 > index_current_chapter - 1:
+        if index_current_chapter - 1 < 0:
             log.info("Book reached start, cannot rewind further.")
 
             chapter = self._book.chapters[0]

--- a/cozy/media/player.py
+++ b/cozy/media/player.py
@@ -589,6 +589,32 @@ class Player(EventSender):
             chapter.position = chapter.start_position
             self.play_pause_chapter(self._book, chapter)
 
+    def _previous_chapter(self):
+        if not self._book:
+            log.error("Cannot play next chapter because no book reference is stored.")
+            reporter.error(
+                "player", "Cannot play next chapter because no book reference is stored."
+            )
+            return
+
+        index_current_chapter = self._book.chapters.index(self._book.current_chapter)
+
+        self._book.current_chapter.position = self._book.current_chapter.start_position
+        print('index', index_current_chapter)
+        if 0 > index_current_chapter - 1:
+            log.info("Book reached start, cannot rewind further.")
+
+            chapter = self._book.chapters[0]
+            chapter.position = chapter.start_position
+            print(chapter.position, index_current_chapter)
+            self._load_chapter(chapter)
+            self.pause()
+            self._emit_tick()
+        else:
+            chapter = self._book.chapters[index_current_chapter - 1]
+            chapter.position = chapter.start_position
+            self.play_pause_chapter(self._book, chapter)
+
     def _on_importer_event(self, event: str, message):
         if event == "scan" and message == ScanStatus.SUCCESS:
             log.info("Reloading current book")

--- a/cozy/media/player.py
+++ b/cozy/media/player.py
@@ -591,22 +591,20 @@ class Player(EventSender):
 
     def _previous_chapter(self):
         if not self._book:
-            log.error("Cannot play next chapter because no book reference is stored.")
+            log.error("Cannot play previous chapter because no book reference is stored.")
             reporter.error(
-                "player", "Cannot play next chapter because no book reference is stored."
+                "player", "Cannot play previous chapter because no book reference is stored."
             )
             return
 
         index_current_chapter = self._book.chapters.index(self._book.current_chapter)
-
         self._book.current_chapter.position = self._book.current_chapter.start_position
-        print('index', index_current_chapter)
+
         if index_current_chapter - 1 < 0:
             log.info("Book reached start, cannot rewind further.")
-
             chapter = self._book.chapters[0]
             chapter.position = chapter.start_position
-            print(chapter.position, index_current_chapter)
+
             self._load_chapter(chapter)
             self.pause()
             self._emit_tick()

--- a/cozy/ui/about_window.py
+++ b/cozy/ui/about_window.py
@@ -22,6 +22,8 @@ class AboutWindow:
 
         self.set_extra_credits()
 
+        self.connect = self._window.connect
+
     def get_contributors(self) -> list[str]:
         authors_file = Gio.resources_lookup_data(
             "/com/github/geigi/cozy/appdata/authors.list", Gio.ResourceLookupFlags.NONE

--- a/cozy/ui/main_view.py
+++ b/cozy/ui/main_view.py
@@ -203,7 +203,6 @@ class CozyUI(EventSender, metaclass=Singleton):
         """
         sensitive = not block
         try:
-            self.set_hotkeys_enabled(sensitive)
             if scan:
                 self.scan_action.set_enabled(sensitive)
                 self.hide_offline_action.set_enabled(sensitive)

--- a/cozy/ui/main_view.py
+++ b/cozy/ui/main_view.py
@@ -105,26 +105,41 @@ class CozyUI(EventSender, metaclass=Singleton):
         self.create_action("prefs", self.show_preferences_window, ["<primary>comma"])
         self.create_action("quit", self.quit, ["<primary>q", "<primary>w"])
 
-        self.create_action("seek_forward", self.seek_forward, ["Right"])
-        self.create_action("seek_rewind", self.seek_rewind, ["Left"])
-
-        self.create_action("volume_up", self.volume_up, ["Up"])
-        self.create_action("volume_down", self.volume_down, ["Down"])
-
-        self.create_action("speed_up", self.speed_up, ['plus', 'equal'])
-        self.create_action("speed_down", self.speed_down, ['minus', 'hyphen'])
-
-        self.create_action("previous_chapter", self.previous_chapter, ["Page_Down", "bracketleft", "braceleft"])
-        self.create_action("next_chapter", self.next_chapter, ["Page_Up", "bracketright", "braceright"])
-
         self.scan_action = self.create_action("scan", self.scan)
         self.play_pause_action = self.create_action("play_pause", self.play_pause, ["space"])
+
+        self.seek_forward_action = self.create_action("seek_forward", self.seek_forward, ["Right"])
+        self.seek_rewind_action = self.create_action("seek_rewind", self.seek_rewind, ["Left"])
+
+        self.volume_up_action = self.create_action("volume_up", self.volume_up, ["Up"])
+        self.volume_down_action = self.create_action("volume_down", self.volume_down, ["Down"])
+
+        self.speed_up_action = self.create_action("speed_up", self.speed_up, ['plus', 'equal'])
+        self.speed_down_action = self.create_action("speed_down", self.speed_down, ['minus', 'hyphen'])
+
+        self.previous_chapter_action = self.create_action("previous_chapter", self.previous_chapter, ["Page_Down", "bracketleft", "braceleft"])
+        self.next_chapter_action = self.create_action("next_chapter", self.next_chapter, ["Page_Up", "bracketright", "braceright"])
 
         self.hide_offline_action = Gio.SimpleAction.new_stateful(
             "hide_offline", None, GLib.Variant.new_boolean(self.application_settings.hide_offline)
         )
         self.hide_offline_action.connect("change-state", self.__on_hide_offline)
         self.app.add_action(self.hide_offline_action)
+
+    def set_keyboard_shortcuts_enabled(self, enabled):
+        self.play_pause_action.set_enabled(enabled)
+
+        self.seek_forward_action.set_enabled(enabled)
+        self.seek_rewind_action.set_enabled(enabled)
+
+        self.volume_up_action.set_enabled(enabled)
+        self.volume_down_action.set_enabled(enabled)
+
+        self.speed_up_action.set_enabled(enabled)
+        self.speed_down_action.set_enabled(enabled)
+
+        self.previous_chapter_action.set_enabled(enabled)
+        self.next_chapter_action.set_enabled(enabled)
 
     def __init_components(self):
         path = self._settings.default_location.path if self._settings.storage_locations else None

--- a/cozy/ui/main_view.py
+++ b/cozy/ui/main_view.py
@@ -114,8 +114,8 @@ class CozyUI(EventSender, metaclass=Singleton):
         self.create_action("speed_up", self.speed_up, ['plus', 'equal'])
         self.create_action("speed_down", self.speed_down, ['minus', 'hyphen'])
 
-        self.create_action("previous_chapter", self.previous_chapter, ["Page_Down", "bracketleft"])
-        self.create_action("next_chapter", self.next_chapter, ["Page_Up", "bracketright"])
+        self.create_action("previous_chapter", self.previous_chapter, ["Page_Down", "bracketleft", "braceleft"])
+        self.create_action("next_chapter", self.next_chapter, ["Page_Up", "bracketright", "braceright"])
 
         self.scan_action = self.create_action("scan", self.scan)
         self.play_pause_action = self.create_action("play_pause", self.play_pause, ["space"])

--- a/cozy/ui/main_view.py
+++ b/cozy/ui/main_view.py
@@ -15,16 +15,14 @@ from cozy.media.files import Files
 from cozy.media.importer import Importer, ScanStatus
 from cozy.media.player import Player
 from cozy.model.settings import Settings as SettingsModel
-
 from cozy.ui.about_window import AboutWindow
 from cozy.ui.book_detail_view import BookDetailView
 from cozy.ui.library_view import LibraryView
 from cozy.ui.preferences_window import PreferencesWindow
 from cozy.ui.widgets.first_import_button import FirstImportButton
-
-from cozy.view_model.storages_view_model import StoragesViewModel
 from cozy.view_model.playback_control_view_model import PlaybackControlViewModel
 from cozy.view_model.playback_speed_view_model import PlaybackSpeedViewModel
+from cozy.view_model.storages_view_model import StoragesViewModel
 
 log = logging.getLogger("ui")
 
@@ -63,7 +61,9 @@ class CozyUI(EventSender, metaclass=Singleton):
         self.check_for_tracks()
 
     def startup(self):
-        self.window_builder = Gtk.Builder.new_from_resource("/com/github/geigi/cozy/ui/main_window.ui")
+        self.window_builder = Gtk.Builder.new_from_resource(
+            "/com/github/geigi/cozy/ui/main_window.ui"
+        )
         self.window: Adw.ApplicationWindow = self.window_builder.get_object("app_window")
 
     def __init_window(self):
@@ -214,7 +214,10 @@ class CozyUI(EventSender, metaclass=Singleton):
         Switch the UI state back to playing.
         This enables all UI functionality for the user.
         """
-        if self.navigation_view.props.visible_page != "book_overview" and self.main_stack.props.visible_child_name != "welcome":
+        if (
+            self.navigation_view.props.visible_page != "book_overview"
+            and self.main_stack.props.visible_child_name != "welcome"
+        ):
             self.navigation_view.pop_to_tag("main")
 
         if self._player.loaded_book:
@@ -314,4 +317,3 @@ class CozyUI(EventSender, metaclass=Singleton):
         self.application_settings.window_width = width
         self.application_settings.window_height = height
         self.application_settings.window_maximize = self.window.is_maximized()
-

--- a/cozy/ui/main_view.py
+++ b/cozy/ui/main_view.py
@@ -114,6 +114,9 @@ class CozyUI(EventSender, metaclass=Singleton):
         self.create_action("speed_up", self.speed_up, ['plus', 'equal'])
         self.create_action("speed_down", self.speed_down, ['minus', 'hyphen'])
 
+        self.create_action("previous_chapter", self.previous_chapter, ["Page_Down", "bracketleft"])
+        self.create_action("next_chapter", self.next_chapter, ["Page_Up", "bracketright"])
+
         self.scan_action = self.create_action("scan", self.scan)
         self.play_pause_action = self.create_action("play_pause", self.play_pause, ["space"])
 
@@ -198,6 +201,12 @@ class CozyUI(EventSender, metaclass=Singleton):
 
     def speed_down(self, *_):
         self._playback_speed_view_model.speed_down()
+
+    def next_chapter(self, *_):
+        self._player._next_chapter()
+
+    def previous_chapter(self, *_):
+        self._player._previous_chapter()
 
     def block_ui_buttons(self, block, scan=False):
         """

--- a/cozy/ui/main_view.py
+++ b/cozy/ui/main_view.py
@@ -98,15 +98,15 @@ class CozyUI(EventSender, metaclass=Singleton):
         """
         Init all app actions.
         """
-        self.create_action("about", self.show_about_window, ["F1"])
+        self.create_action("about", self.show_about_window, ["F1"], global_shorcut=True)
         self.create_action("reset_book", self.reset_book)
         self.create_action("remove_book", self.remove_book)
 
         self.create_action("mark_book_as_read", self.mark_book_as_read)
         self.create_action("jump_to_book_folder", self.jump_to_book_folder)
 
-        self.create_action("prefs", self.show_preferences_window, ["<primary>comma"])
-        self.create_action("quit", self.quit, ["<primary>q", "<primary>w"])
+        self.create_action("prefs", self.show_preferences_window, ["<primary>comma"], global_shorcut=True)
+        self.create_action("quit", self.quit, ["<primary>q", "<primary>w"], global_shorcut=True)
 
         self.scan_action = self.create_action("scan", self.scan)
 
@@ -136,7 +136,7 @@ class CozyUI(EventSender, metaclass=Singleton):
         callback: Callable[[Gio.SimpleAction, None], None],
         shortcuts: list[str] | None = None,
         *,
-        only_main_view: bool = False,
+        global_shorcut: bool = False,
     ) -> Gio.SimpleAction:
         action = Gio.SimpleAction.new(name, None)
         action.connect("activate", callback)
@@ -145,7 +145,7 @@ class CozyUI(EventSender, metaclass=Singleton):
         if shortcuts:
             self.app.set_accels_for_action(f"app.{name}", shortcuts)
 
-        if only_main_view:
+        if not global_shorcut:
             self._actions_to_disable.append(action)
 
         return action

--- a/cozy/ui/main_view.py
+++ b/cozy/ui/main_view.py
@@ -15,13 +15,16 @@ from cozy.media.files import Files
 from cozy.media.importer import Importer, ScanStatus
 from cozy.media.player import Player
 from cozy.model.settings import Settings as SettingsModel
+
 from cozy.ui.about_window import AboutWindow
 from cozy.ui.book_detail_view import BookDetailView
 from cozy.ui.library_view import LibraryView
 from cozy.ui.preferences_window import PreferencesWindow
 from cozy.ui.widgets.first_import_button import FirstImportButton
+
 from cozy.view_model.storages_view_model import StoragesViewModel
 from cozy.view_model.playback_control_view_model import PlaybackControlViewModel
+from cozy.view_model.playback_speed_view_model import PlaybackSpeedViewModel
 
 log = logging.getLogger("ui")
 
@@ -38,6 +41,7 @@ class CozyUI(EventSender, metaclass=Singleton):
     _player: Player = inject.attr(Player)
     _storages_view_model: StoragesViewModel = inject.attr(StoragesViewModel)
     _playback_control_view_model: PlaybackControlViewModel = inject.attr(PlaybackControlViewModel)
+    _playback_speed_view_model: PlaybackSpeedViewModel = inject.attr(PlaybackSpeedViewModel)
 
     _library_view: LibraryView
 
@@ -106,6 +110,9 @@ class CozyUI(EventSender, metaclass=Singleton):
 
         self.create_action("volume_up", self.volume_up, ["Up"])
         self.create_action("volume_down", self.volume_down, ["Down"])
+
+        self.create_action("speed_up", self.speed_up, ['plus', 'equal'])
+        self.create_action("speed_down", self.speed_down, ['minus', 'hyphen'])
 
         self.scan_action = self.create_action("scan", self.scan)
         self.play_pause_action = self.create_action("play_pause", self.play_pause, ["space"])
@@ -185,6 +192,12 @@ class CozyUI(EventSender, metaclass=Singleton):
     def volume_down(self, *_):
         self._player.volume_down()
         self.app.app_controller.media_controller._on_volume_changed()
+
+    def speed_up(self, *_):
+        self._playback_speed_view_model.speed_up()
+
+    def speed_down(self, *_):
+        self._playback_speed_view_model.speed_down()
 
     def block_ui_buttons(self, block, scan=False):
         """

--- a/cozy/ui/main_view.py
+++ b/cozy/ui/main_view.py
@@ -104,6 +104,9 @@ class CozyUI(EventSender, metaclass=Singleton):
         self.create_action("seek_forward", self.seek_forward, ["Right"])
         self.create_action("seek_rewind", self.seek_rewind, ["Left"])
 
+        self.create_action("volume_up", self.volume_up, ["Up"])
+        self.create_action("volume_down", self.volume_down, ["Down"])
+
         self.scan_action = self.create_action("scan", self.scan)
         self.play_pause_action = self.create_action("play_pause", self.play_pause, ["space"])
 
@@ -174,6 +177,14 @@ class CozyUI(EventSender, metaclass=Singleton):
 
     def seek_rewind(self, *_):
         self._playback_control_view_model.rewind()
+
+    def volume_up(self, *_):
+        self._player.volume_up()
+        self.app.app_controller.media_controller._on_volume_changed()
+
+    def volume_down(self, *_):
+        self._player.volume_down()
+        self.app.app_controller.media_controller._on_volume_changed()
 
     def block_ui_buttons(self, block, scan=False):
         """

--- a/cozy/ui/main_view.py
+++ b/cozy/ui/main_view.py
@@ -181,19 +181,19 @@ class CozyUI(EventSender, metaclass=Singleton):
         self.app.quit()
 
     def _dialog_close_callback(self, dialog):
-        dialog.disconnect_by_func(self._callback)
+        dialog.disconnect_by_func(self._dialog_close_callback)
         self.set_hotkeys_enabled(True)
 
     def show_about_window(self, *_):
         self.set_hotkeys_enabled(False)
         about = AboutWindow(self.version)
-        about.connect("closed", self._callback)
+        about.connect("closed", self._dialog_close_callback)
         about.present(self.window)
 
     def show_preferences_window(self, *_):
         self.set_hotkeys_enabled(False)
         prefs = PreferencesWindow()
-        prefs.connect("closed", self._callback)
+        prefs.connect("closed", self._dialog_close_callback)
         prefs.present(self.window)
 
     def block_ui_buttons(self, block, scan=False):

--- a/cozy/ui/main_view.py
+++ b/cozy/ui/main_view.py
@@ -21,6 +21,7 @@ from cozy.ui.library_view import LibraryView
 from cozy.ui.preferences_window import PreferencesWindow
 from cozy.ui.widgets.first_import_button import FirstImportButton
 from cozy.view_model.storages_view_model import StoragesViewModel
+from cozy.view_model.playback_control_view_model import PlaybackControlViewModel
 
 log = logging.getLogger("ui")
 
@@ -36,6 +37,7 @@ class CozyUI(EventSender, metaclass=Singleton):
     _files: Files = inject.attr(Files)
     _player: Player = inject.attr(Player)
     _storages_view_model: StoragesViewModel = inject.attr(StoragesViewModel)
+    _playback_control_view_model: PlaybackControlViewModel = inject.attr(PlaybackControlViewModel)
 
     _library_view: LibraryView
 
@@ -92,10 +94,16 @@ class CozyUI(EventSender, metaclass=Singleton):
         """
         self.create_action("about", self.show_about_window, ["F1"])
         self.create_action("remove_book", self.remove_book)
+
         self.create_action("mark_book_as_read", self.mark_book_as_read)
         self.create_action("jump_to_book_folder", self.jump_to_book_folder)
+
         self.create_action("prefs", self.show_preferences_window, ["<primary>comma"])
         self.create_action("quit", self.quit, ["<primary>q", "<primary>w"])
+
+        self.create_action("seek_forward", self.seek_forward, ["Right"])
+        self.create_action("seek_rewind", self.seek_rewind, ["Left"])
+
         self.scan_action = self.create_action("scan", self.scan)
         self.play_pause_action = self.create_action("play_pause", self.play_pause, ["space"])
 
@@ -160,6 +168,12 @@ class CozyUI(EventSender, metaclass=Singleton):
 
     def play_pause(self, *_):
         self._player.play_pause()
+
+    def seek_forward(self, *_):
+        self._playback_control_view_model.forward()
+
+    def seek_rewind(self, *_):
+        self._playback_control_view_model.rewind()
 
     def block_ui_buttons(self, block, scan=False):
         """

--- a/cozy/ui/media_controller.py
+++ b/cozy/ui/media_controller.py
@@ -107,18 +107,33 @@ class MediaController(Adw.BreakpointBin):
     @inject.param("main_window", "MainWindow")
     def _setup_shortcuts(self, main_window):
         main_window.create_action("play_pause", self._play_clicked, ["space"], only_main_view=True)
-        main_window.create_action("seek_rewind", self._rewind_clicked, ["Left"], only_main_view=True)
-        main_window.create_action("seek_forward", self._forward_clicked, ["Right"], only_main_view=True)
+        main_window.create_action(
+            "seek_rewind", self._rewind_clicked, ["Left"], only_main_view=True
+        )
+        main_window.create_action(
+            "seek_forward", self._forward_clicked, ["Right"], only_main_view=True
+        )
 
         main_window.create_action("volume_up", self._volume_up, ["Up"], only_main_view=True)
         main_window.create_action("volume_down", self._volume_down, ["Down"], only_main_view=True)
 
-        main_window.create_action("speed_up", self._speed_up, ["plus", "KP_Add"], only_main_view=True)
-        main_window.create_action("speed_down", self._speed_down, ['minus',  "KP_Subtract", 'hyphen'], only_main_view=True)
-        main_window.create_action("speed_reset", self._speed_reset, ['equal'], only_main_view=True)
+        main_window.create_action(
+            "speed_up", self._speed_up, ["plus", "KP_Add"], only_main_view=True
+        )
+        main_window.create_action(
+            "speed_down", self._speed_down, ["minus", "KP_Subtract", "hyphen"], only_main_view=True
+        )
+        main_window.create_action("speed_reset", self._speed_reset, ["equal"], only_main_view=True)
 
-        main_window.create_action("previous_chapter", self._previous_chapter, ["Page_Down", "<primary>Left"], only_main_view=True)
-        main_window.create_action("next_chapter", self._next_chapter, ["Page_Up", "<primary>Right"], only_main_view=True)
+        main_window.create_action(
+            "previous_chapter",
+            self._previous_chapter,
+            ["Page_Down", "<primary>Left"],
+            only_main_view=True,
+        )
+        main_window.create_action(
+            "next_chapter", self._next_chapter, ["Page_Up", "<primary>Right"], only_main_view=True
+        )
 
     def _on_book_changed(self) -> None:
         book = self._playback_control_view_model.book

--- a/cozy/ui/media_controller.py
+++ b/cozy/ui/media_controller.py
@@ -126,10 +126,7 @@ class MediaController(Adw.BreakpointBin):
         main_window.create_action("speed_reset", self._speed_reset, ["equal"], only_main_view=True)
 
         main_window.create_action(
-            "previous_chapter",
-            self._previous_chapter,
-            ["Page_Down", "<primary>Left"],
-            only_main_view=True,
+            "prev_chapter", self._prev_chapter, ["Page_Down", "<primary>Left"], only_main_view=True
         )
         main_window.create_action(
             "next_chapter", self._next_chapter, ["Page_Up", "<primary>Right"], only_main_view=True
@@ -195,7 +192,7 @@ class MediaController(Adw.BreakpointBin):
     def _next_chapter(self, *_):
         self._playback_control_view_model.next_chapter()
 
-    def _previous_chapter(self, *_):
+    def _prev_chapter(self, *_):
         self._playback_control_view_model.previous_chapter()
 
     def _play_clicked(self, *_):

--- a/cozy/ui/media_controller.py
+++ b/cozy/ui/media_controller.py
@@ -106,31 +106,19 @@ class MediaController(Adw.BreakpointBin):
 
     @inject.param("main_window", "MainWindow")
     def _setup_shortcuts(self, main_window):
-        main_window.create_action("play_pause", self._play_clicked, ["space"], only_main_view=True)
-        main_window.create_action(
-            "seek_rewind", self._rewind_clicked, ["Left"], only_main_view=True
-        )
-        main_window.create_action(
-            "seek_forward", self._forward_clicked, ["Right"], only_main_view=True
-        )
+        main_window.create_action("play_pause", self._play_clicked, ["space"])
+        main_window.create_action("seek_rewind", self._rewind_clicked, ["Left"])
+        main_window.create_action("seek_forward", self._forward_clicked, ["Right"])
 
-        main_window.create_action("volume_up", self._volume_up, ["Up"], only_main_view=True)
-        main_window.create_action("volume_down", self._volume_down, ["Down"], only_main_view=True)
+        main_window.create_action("volume_up", self._volume_up, ["Up"])
+        main_window.create_action("volume_down", self._volume_down, ["Down"])
 
-        main_window.create_action(
-            "speed_up", self._speed_up, ["plus", "KP_Add", "<primary>Up"], only_main_view=True
-        )
-        main_window.create_action(
-            "speed_down", self._speed_down, ["minus", "KP_Subtract", "<primary>Down"], only_main_view=True
-        )
-        main_window.create_action("speed_reset", self._speed_reset, ["equal"], only_main_view=True)
+        main_window.create_action("speed_up", self._speed_up, ["plus", "KP_Add", "<primary>Up"])
+        main_window.create_action("speed_down", self._speed_down, ["minus", "KP_Subtract", "<primary>Down"])
+        main_window.create_action("speed_reset", self._speed_reset, ["equal"])
 
-        main_window.create_action(
-            "prev_chapter", self._prev_chapter, ["Page_Down", "<primary>Left"], only_main_view=True
-        )
-        main_window.create_action(
-            "next_chapter", self._next_chapter, ["Page_Up", "<primary>Right"], only_main_view=True
-        )
+        main_window.create_action("prev_chapter", self._prev_chapter, ["Page_Down", "<primary>Left"])
+        main_window.create_action("next_chapter", self._next_chapter, ["Page_Up", "<primary>Right"])
 
     def _on_book_changed(self) -> None:
         book = self._playback_control_view_model.book

--- a/cozy/ui/media_controller.py
+++ b/cozy/ui/media_controller.py
@@ -118,10 +118,10 @@ class MediaController(Adw.BreakpointBin):
         main_window.create_action("volume_down", self._volume_down, ["Down"], only_main_view=True)
 
         main_window.create_action(
-            "speed_up", self._speed_up, ["plus", "KP_Add"], only_main_view=True
+            "speed_up", self._speed_up, ["plus", "KP_Add", "<primary>Up"], only_main_view=True
         )
         main_window.create_action(
-            "speed_down", self._speed_down, ["minus", "KP_Subtract", "hyphen"], only_main_view=True
+            "speed_down", self._speed_down, ["minus", "KP_Subtract", "<primary>Down"], only_main_view=True
         )
         main_window.create_action("speed_reset", self._speed_reset, ["equal"], only_main_view=True)
 

--- a/cozy/ui/media_controller.py
+++ b/cozy/ui/media_controller.py
@@ -113,11 +113,12 @@ class MediaController(Adw.BreakpointBin):
         main_window.create_action("volume_up", self._volume_up, ["Up"], only_main_view=True)
         main_window.create_action("volume_down", self._volume_down, ["Down"], only_main_view=True)
 
-        main_window.create_action("speed_up", self._speed_up, ['plus', 'equal'], only_main_view=True)
-        main_window.create_action("speed_down", self._speed_down, ['minus', 'hyphen'], only_main_view=True)
+        main_window.create_action("speed_up", self._speed_up, ["plus", "KP_Add"], only_main_view=True)
+        main_window.create_action("speed_down", self._speed_down, ['minus',  "KP_Subtract", 'hyphen'], only_main_view=True)
+        main_window.create_action("speed_reset", self._speed_reset, ['equal'], only_main_view=True)
 
-        main_window.create_action("previous_chapter", self._previous_chapter, ["Page_Down", "bracketleft", "braceleft"], only_main_view=True)
-        main_window.create_action("next_chapter", self._next_chapter, ["Page_Up", "bracketright", "braceright"], only_main_view=True)
+        main_window.create_action("previous_chapter", self._previous_chapter, ["Page_Down", "<primary>Left"], only_main_view=True)
+        main_window.create_action("next_chapter", self._next_chapter, ["Page_Up", "<primary>Right"], only_main_view=True)
 
     def _on_book_changed(self) -> None:
         book = self._playback_control_view_model.book
@@ -172,6 +173,9 @@ class MediaController(Adw.BreakpointBin):
 
     def _speed_down(self, *_):
         self._playback_speed_view_model.speed_down()
+
+    def _speed_reset(self, *_):
+        self._playback_speed_view_model.speed_reset()
 
     def _next_chapter(self, *_):
         self._playback_control_view_model.next_chapter()

--- a/cozy/ui/search_view.py
+++ b/cozy/ui/search_view.py
@@ -54,12 +54,12 @@ class SearchView(Adw.Bin):
     def open(self, *_) -> None:
         self.library_stack.set_visible_child(self)
         self.search_bar.set_search_mode(True)
-        self.main_view.set_keyboard_shortcuts_enabled(False)
+        self.main_view.set_hotkeys_enabled(False)
 
     def close(self) -> None:
         self.library_stack.set_visible_child(self.split_view)
         self.search_bar.set_search_mode(False)
-        self.main_view.set_keyboard_shortcuts_enabled(True)
+        self.main_view.set_hotkeys_enabled(True)
 
     def on_state_changed(self, widget: Gtk.Widget, param) -> None:
         if widget.get_property(param.name):

--- a/cozy/ui/search_view.py
+++ b/cozy/ui/search_view.py
@@ -54,12 +54,12 @@ class SearchView(Adw.Bin):
     def open(self, *_) -> None:
         self.library_stack.set_visible_child(self)
         self.search_bar.set_search_mode(True)
-        self.main_view.play_pause_action.set_enabled(False)
+        self.main_view.set_keyboard_shortcuts_enabled(False)
 
     def close(self) -> None:
         self.library_stack.set_visible_child(self.split_view)
         self.search_bar.set_search_mode(False)
-        self.main_view.play_pause_action.set_enabled(True)
+        self.main_view.set_keyboard_shortcuts_enabled(True)
 
     def on_state_changed(self, widget: Gtk.Widget, param) -> None:
         if widget.get_property(param.name):

--- a/cozy/ui/widgets/book_card.py
+++ b/cozy/ui/widgets/book_card.py
@@ -105,12 +105,8 @@ class BookCard(Gtk.FlowBoxChild):
         long_press_gesture = Gtk.GestureLongPress()
         long_press_gesture.connect("pressed", self._on_long_tap)
 
-        key_event_controller = Gtk.EventControllerKey()
-        key_event_controller.connect("key-pressed", self._on_key_press_event)
-
         self.add_controller(hover_controller)
         self.add_controller(long_press_gesture)
-        self.add_controller(key_event_controller)
 
     def set_playing(self, is_playing):
         self.play_button.set_playing(is_playing)
@@ -160,7 +156,3 @@ class BookCard(Gtk.FlowBoxChild):
         device = gesture.get_device()
         if device and device.get_source() == Gdk.InputSource.TOUCHSCREEN:
             self.menu_button.emit("activate")
-
-    def _on_key_press_event(self, controller, keyval, *_):
-        if keyval == Gdk.KEY_Return:
-            self.emit("open-book-overview", self.book)

--- a/cozy/ui/widgets/seek_bar.py
+++ b/cozy/ui/widgets/seek_bar.py
@@ -1,4 +1,4 @@
-from gi.repository import Gdk, GObject, Gtk
+from gi.repository import GObject, Gtk
 
 from cozy.control.time_format import ns_to_time
 

--- a/cozy/ui/widgets/seek_bar.py
+++ b/cozy/ui/widgets/seek_bar.py
@@ -37,10 +37,6 @@ class SeekBar(Gtk.Box):
         click_gesture.connect("pressed", self._on_progress_scale_press)
         click_gesture.connect("released", self._on_progress_scale_release)
 
-        keyboard_controller = Gtk.EventControllerKey()
-        keyboard_controller.connect("key-pressed", self._on_progress_key_pressed)
-        self.progress_scale.add_controller(keyboard_controller)
-
     @GObject.Signal(arg_types=(object,))
     def position_changed(self, *_): ...
 
@@ -89,12 +85,6 @@ class SeekBar(Gtk.Box):
         self._progress_scale_pressed = False
         value = self.progress_scale.get_value()
         self.emit("position-changed", value)
-
-    def _on_progress_key_pressed(self, _, event, *__):
-        if event in {Gdk.KEY_Up, Gdk.KEY_Left}:
-            self.emit("rewind")
-        elif event in {Gdk.KEY_Down, Gdk.KEY_Right}:
-            self.emit("forward")
 
     def _on_progress_scale_press(self, *_):
         self._progress_scale_pressed = True

--- a/cozy/view_model/playback_control_view_model.py
+++ b/cozy/view_model/playback_control_view_model.py
@@ -94,9 +94,11 @@ class PlaybackControlViewModel(Observable, EventSender):
 
     def rewind(self):
         self._player.rewind()
+        self._player._emit_tick()
 
     def forward(self):
         self._player.forward()
+        self._player._emit_tick()
 
     def open_book_detail(self):
         if self.book:

--- a/cozy/view_model/playback_control_view_model.py
+++ b/cozy/view_model/playback_control_view_model.py
@@ -100,6 +100,20 @@ class PlaybackControlViewModel(Observable, EventSender):
         self._player.forward()
         self._player._emit_tick()
 
+    def next_chapter(self):
+        self._player._next_chapter()
+
+    def previous_chapter(self):
+        self._player._previous_chapter()
+
+    def volume_up(self):
+        self._player.volume_up()
+        self._notify("volume")
+
+    def volume_down(self):
+        self._player.volume_down()
+        self._notify("volume")
+
     def open_book_detail(self):
         if self.book:
             self.emit_event(OpenView.BOOK, self.book)

--- a/cozy/view_model/playback_speed_view_model.py
+++ b/cozy/view_model/playback_speed_view_model.py
@@ -34,3 +34,11 @@ class PlaybackSpeedViewModel(Observable, EventSender):
         if event == "chapter-changed" and message:
             self._book = message
             self._notify("playback_speed")
+
+    def speed_up(self):
+        self.playback_speed = min(self.playback_speed + .1, 3.5)
+        self._notify("playback_speed")
+
+    def speed_down(self):
+        self.playback_speed = max(self.playback_speed - .1, 0.5)
+        self._notify("playback_speed")

--- a/cozy/view_model/playback_speed_view_model.py
+++ b/cozy/view_model/playback_speed_view_model.py
@@ -42,3 +42,7 @@ class PlaybackSpeedViewModel(Observable, EventSender):
     def speed_down(self):
         self.playback_speed = max(self.playback_speed - .1, 0.5)
         self._notify("playback_speed")
+
+    def speed_reset(self):
+        self.playback_speed = 1.0
+        self._notify("playback_speed")

--- a/cozy/view_model/playback_speed_view_model.py
+++ b/cozy/view_model/playback_speed_view_model.py
@@ -36,11 +36,11 @@ class PlaybackSpeedViewModel(Observable, EventSender):
             self._notify("playback_speed")
 
     def speed_up(self):
-        self.playback_speed = min(self.playback_speed + .1, 3.5)
+        self.playback_speed = min(self.playback_speed + 0.1, 3.5)
         self._notify("playback_speed")
 
     def speed_down(self):
-        self.playback_speed = max(self.playback_speed - .1, 0.5)
+        self.playback_speed = max(self.playback_speed - 0.1, 0.5)
         self._notify("playback_speed")
 
     def speed_reset(self):

--- a/data/ui/book_card.blp
+++ b/data/ui/book_card.blp
@@ -11,14 +11,14 @@ template $BookCard: FlowBoxChild {
         valign: end;
         halign: end;
 
-        $BookElementPlayButton play_button {
+        Button play_button {
           width-request: 54;
           height-request: 54;
           margin-end: 18;
           margin-bottom: 18;
           focusable: true;
           focus-on-click: false;
-          icon_name: "media-playback-start-symbolic";
+          icon-name: "media-playback-start-symbolic";
           tooltip-text: _("Start/Stop playback");
 
           clicked => $_play_pause();

--- a/data/ui/book_card.blp
+++ b/data/ui/book_card.blp
@@ -11,14 +11,14 @@ template $BookCard: FlowBoxChild {
         valign: end;
         halign: end;
 
-        Button play_button {
+        $BookElementPlayButton play_button {
           width-request: 54;
           height-request: 54;
           margin-end: 18;
           margin-bottom: 18;
           focusable: true;
           focus-on-click: false;
-          icon-name: "media-playback-start-symbolic";
+          icon_name: "media-playback-start-symbolic";
           tooltip-text: _("Start/Stop playback");
 
           clicked => $_play_pause();

--- a/data/ui/headerbar.blp
+++ b/data/ui/headerbar.blp
@@ -22,6 +22,7 @@ template $Headerbar: Box {
       tooltip-text: _("Options");
       menu-model: primary_menu;
       icon-name: 'open-menu-symbolic';
+      primary: true;
 
       accessibility {
         label: _("Open the options popover");


### PR DESCRIPTION
A few issues have been asking for this, and the other PR is incomplete, so I thought I would just do it.

The new keybinds are:
- Up/Down for volume controls
- +/- for player speed (and -/= so you dont need to hold shift)
- the bracket keys []  and {} to skip ahead in chapters, along with Page Up and Down,

The left/right arrow key controls have been moved so focusing on the main page should work to seek. As a side effect of that is the skip/rewind buttons in the playerbar are slightly more responsive

The search page cant type the brackets or plus minus keys without the current keybinds overriding them, but I'm looking for a fix to that now

EDIT: Search works as expected now