### PR TITLE
Use unofficial Mutagen build to fix chapter times

### DIFF
--- a/com.github.geigi.cozy.json
+++ b/com.github.geigi.cozy.json
@@ -40,8 +40,8 @@
       "sources": [
         {
           "type": "file",
-          "url": "https://files.pythonhosted.org/packages/b0/7a/620f945b96be1f6ee357d211d5bf74ab1b7fe72a9f1525aafbfe3aee6875/mutagen-1.47.0-py3-none-any.whl",
-          "sha256": "edd96f50c5907a9539d8e5bba7245f62c9f520aef333d13392a79a4f70aca719"
+          "url": "https://github.com/LSeelig/mutagen/releases/download/release-1.47.1/mutagen-1.47.1-py3-none-any.whl",
+          "sha256": "099c370f778f66b06f3e5a18e52948e53acdada530911c54090365b9292c99cb"
         }
       ]
     },


### PR DESCRIPTION
This isn't the only chapter bug that might need a custom mutagen wheel, though I would hope that, if this is approved, another repo/host should be used.