### PR TITLE
Temporarily disable uploading Flatpak artifacts

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -41,3 +41,4 @@ jobs:
         manifest-path: com.github.geigi.cozy.json
         cache-key: "flatpak-builder-${{ github.sha }}"
         arch: ${{ matrix.arch }}
+        upload-artifact: false

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         platforms: arm64
 
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@master
       with:
         repository-name: gnome-nightly
         repository-url: https://nightly.gnome.org/gnome-nightly.flatpakrepo


### PR DESCRIPTION
It doesn't work right now, because `flatpak-builder-actions` uses a deprecated version of `upload-artifact`. Upstream ticket here: https://github.com/flatpak/flatpak-github-actions/issues/214