### PR TITLE
Fix ID3 chapter order and length

### DIFF
--- a/cozy/media/tag_reader.py
+++ b/cozy/media/tag_reader.py
@@ -185,9 +185,9 @@ class TagReader:
 
         for index, chapter in enumerate(chaps):
             if index < len(chaps) - 1:
-                length = chapter.end_time - chapter.start_time
+                length = (chapter.end_time - chapter.start_time) / 1000
             else:
-                length = self._get_length_in_seconds() - chapter.start_time
+                length = self._get_length_in_seconds() - chapter.start_time / 1000
 
             sub_frames = chapter.sub_frames.get("TIT2", ())
             title = sub_frames.text[0] if sub_frames else ""
@@ -195,7 +195,7 @@ class TagReader:
             chapters.append(
                 Chapter(
                     name=title,
-                    position=int(chapter.start_time * Gst.SECOND),
+                    position=int(chapter.start_time * Gst.MSECOND),
                     length=length,
                     number=index + 1,
                 )

--- a/cozy/media/tag_reader.py
+++ b/cozy/media/tag_reader.py
@@ -181,7 +181,7 @@ class TagReader:
             return self._get_single_file_chapter()
 
         chapters = []
-        chaps.sort(key=lambda k: k.element_id)
+        chaps.sort(key=lambda k: k.start_time)
 
         for index, chapter in enumerate(chaps):
             if index < len(chaps) - 1:


### PR DESCRIPTION
* ID3 tags are in milliseconds, and mutagen doesn't adjust them. Treating them as seconds resulted in ridiculous chapter lengths being displayed.
* Files with more than 9 chapters had chapters out of order because they were sorted by Element ID. Sorting by start time instead.

It would be more spec compliant to sort the chapters using the Table of Contents, but I doubt there are many files out there that would require it.

ID3v2 Chapter specification: https://id3.org/id3v2-chapters-1.0
Test MP3 file (109 MB): https://cdn.changelog.com/uploads/friends/82/changelog--friends-82.mp3