### PR TITLE
Migrate from using pytz to Zoneinfo

### DIFF
--- a/cozy/report/report_to_loki.py
+++ b/cozy/report/report_to_loki.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 
 import distro
 import inject
-import pytz
+from zoneinfo import ZoneInfo
 import requests
 from gi.repository import Gtk
 from mutagen import version_string as MutagenVersion
@@ -36,7 +36,7 @@ def report(component: str, type: LogLevel, message: str, exception: Exception):
     if report_level == 0:
         return
 
-    curr_datetime = datetime.datetime.now(pytz.timezone('Europe/Berlin'))
+    curr_datetime = datetime.datetime.now(ZoneInfo('Europe/Berlin'))
     curr_datetime = curr_datetime.isoformat('T')
 
     if not component or not type or not message:

--- a/flatpak/python-deps.json
+++ b/flatpak/python-deps.json
@@ -46,20 +46,6 @@
             ]
         },
         {
-            "name": "python3-pytz",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pytz\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl",
-                    "sha256": "5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"
-                }
-            ]
-        },
-        {
             "name": "python3-requests",
             "buildsystem": "simple",
             "build-commands": [

--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,7 @@ else
 endif
 
 # Python 3 required modules
-python3_required_modules = ['distro', 'mutagen', 'peewee', 'pytz', 'requests', 'inject', 'gi']
+python3_required_modules = ['distro', 'mutagen', 'peewee', 'requests', 'inject', 'gi']
 
 foreach p : python3_required_modules
   # Source: https://docs.python.org/3/library/importlib.html#checking-if-a-module-can-be-imported

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 distro
 mutagen>=1.47
 peewee>=3.9.6
-pytz
 requests
 inject
 Pillow


### PR DESCRIPTION
The use of pytz has been deprecated since python 3.9 and it's recommended to use zoneinfo, also in recent releases of the timezone database a change in format is causing issues in some cases with pytz so migrate to use the recommended upstream.