### PR TITLE
ui: fix book card cover size shrinking

### DIFF
--- a/data/ui/book_card.blp
+++ b/data/ui/book_card.blp
@@ -70,6 +70,9 @@ template $BookCard: FlowBoxChild {
           orientation: vertical;
 
           Stack stack {
+            width-request: 200;
+            height-request: 200;
+
             Picture artwork {
               content-fit: cover;
               hexpand: true;


### PR DESCRIPTION
Adds `width-request` and `height-request` to the book_card Stack.

Without these, GtkPicture collapses the child stack inside the Button under newer GTK versions, because there is no strict minimum size allocation. The result is book card covers shrinking unexpectedly. Setting explicit minimum size requests on the Stack fixes the layout.
