### PR TITLE
fix: correct typo 'Recieve' to 'Receive' in translation files

### DIFF
--- a/po/bg.po
+++ b/po/bg.po
@@ -914,7 +914,7 @@ msgid "Close Cozy"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:47
-msgid "Recieve help on GitHub"
+msgid "Receive help on GitHub"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:108

--- a/po/da.po
+++ b/po/da.po
@@ -910,7 +910,7 @@ msgid "Close Cozy"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:47
-msgid "Recieve help on GitHub"
+msgid "Receive help on GitHub"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:108

--- a/po/el.po
+++ b/po/el.po
@@ -927,7 +927,7 @@ msgid "Close Cozy"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:47
-msgid "Recieve help on GitHub"
+msgid "Receive help on GitHub"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:108

--- a/po/ms_MY.po
+++ b/po/ms_MY.po
@@ -947,7 +947,7 @@ msgid "Close Cozy"
 msgstr "Tutup Cozy"
 
 #: data/ui/db_migration_failed.ui:47
-msgid "Recieve help on GitHub"
+msgid "Receive help on GitHub"
 msgstr "Mendapatkan bantuan Github"
 
 #: data/ui/db_migration_failed.ui:108

--- a/po/no.po
+++ b/po/no.po
@@ -922,7 +922,7 @@ msgid "Close Cozy"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:47
-msgid "Recieve help on GitHub"
+msgid "Receive help on GitHub"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:108

--- a/po/pt.po
+++ b/po/pt.po
@@ -931,7 +931,7 @@ msgid "Close Cozy"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:47
-msgid "Recieve help on GitHub"
+msgid "Receive help on GitHub"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:108

--- a/po/zh.po
+++ b/po/zh.po
@@ -914,7 +914,7 @@ msgid "Close Cozy"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:47
-msgid "Recieve help on GitHub"
+msgid "Receive help on GitHub"
 msgstr ""
 
 #: data/ui/db_migration_failed.ui:108


### PR DESCRIPTION
Corrected typo: 'Recieve' → 'Receive' in 7 translation (.po) files.